### PR TITLE
Change all interfaceId fields to use custom.fields.merchantReference instead

### DIFF
--- a/extension/docs/IntegrationGuide.md
+++ b/extension/docs/IntegrationGuide.md
@@ -102,7 +102,7 @@ or by asynchronous process like [commercetools-payment-to-order-processor job](h
 ### Validate payment
 There must be at least one CTP payment object of type Adyen
 (`Payment.paymentMethodInfo.paymentInterface = ctp-adyen-integration`)
-AND this CTP payment must have `Payment.custom.fields.interfaceId`.
+AND this CTP payment must have `Payment.custom.fields.merchantReference`.
 
 ### Validate payment transaction
 Cart's payment counts as successful if there is at least one payment object

--- a/extension/docs/IntegrationGuide.md
+++ b/extension/docs/IntegrationGuide.md
@@ -103,6 +103,7 @@ or by asynchronous process like [commercetools-payment-to-order-processor job](h
 There must be at least one CTP payment object of type Adyen
 (`Payment.paymentMethodInfo.paymentInterface = ctp-adyen-integration`)
 AND this CTP payment must have `Payment.custom.fields.merchantReference`.
+The combination of `Payment.custom.fields.merchantReference` and `Payment.paymentMethodInfo.paymentInterface` must be unique across the project. This field must not be changed once set.
 
 ### Validate payment transaction
 Cart's payment counts as successful if there is at least one payment object

--- a/extension/docs/IntegrationGuide.md
+++ b/extension/docs/IntegrationGuide.md
@@ -102,7 +102,7 @@ or by asynchronous process like [commercetools-payment-to-order-processor job](h
 ### Validate payment
 There must be at least one CTP payment object of type Adyen
 (`Payment.paymentMethodInfo.paymentInterface = ctp-adyen-integration`)
-AND this CTP payment must have `Payment.interfaceId`.
+AND this CTP payment must have `Payment.custom.fields.interfaceId`.
 
 ### Validate payment transaction
 Cart's payment counts as successful if there is at least one payment object

--- a/extension/resources/payment-custom-types.json
+++ b/extension/resources/payment-custom-types.json
@@ -11,6 +11,17 @@
       "type": {
         "name": "String"
       },
+      "name": "interfaceId",
+      "label": {
+        "en": "interfaceId"
+      },
+      "required": true,
+      "inputHint": "SingleLine"
+    },
+    {
+      "type": {
+        "name": "String"
+      },
       "name": "payload",
       "label": {
         "en": "payload"

--- a/extension/resources/payment-custom-types.json
+++ b/extension/resources/payment-custom-types.json
@@ -11,9 +11,9 @@
       "type": {
         "name": "String"
       },
-      "name": "interfaceId",
+      "name": "merchantReference",
       "label": {
-        "en": "interfaceId"
+        "en": "merchantReference"
       },
       "required": true,
       "inputHint": "SingleLine"

--- a/extension/src/api/payment/payment.controller.js
+++ b/extension/src/api/payment/payment.controller.js
@@ -27,13 +27,13 @@ async function processRequest (request, response) {
   if (adyenValidator.hasErrors())
   // if it's not adyen payment, ignore the payment
     return httpUtils.sendResponse({ response })
-  const interfaceIdValidator = validatorBuilder
-    .validateInterfaceIdField()
-  if (interfaceIdValidator.hasErrors())
+  const merchantReferenceValidator = validatorBuilder
+    .validateMerchantReferenceField()
+  if (merchantReferenceValidator.hasErrors())
     return httpUtils.sendResponse({
       response,
       statusCode: 400,
-      data: interfaceIdValidator.buildCtpErrorResponse()
+      data: merchantReferenceValidator.buildCtpErrorResponse()
     })
   const paymentMethodValidator = validatorBuilder.validatePaymentMethod()
   if (paymentMethodValidator.hasErrors())

--- a/extension/src/paymentHandler/cancel-or-refund.handler.js
+++ b/extension/src/paymentHandler/cancel-or-refund.handler.js
@@ -34,7 +34,7 @@ async function _cancelOrRefundPayment (paymentObject) {
   const body = {
     merchantAccount: config.adyen.merchantAccount,
     originalReference: transaction.interactionId,
-    reference: paymentObject.interfaceId
+    reference: paymentObject.custom.fields.interfaceId
   }
 
   const request = {

--- a/extension/src/paymentHandler/cancel-or-refund.handler.js
+++ b/extension/src/paymentHandler/cancel-or-refund.handler.js
@@ -34,7 +34,7 @@ async function _cancelOrRefundPayment (paymentObject) {
   const body = {
     merchantAccount: config.adyen.merchantAccount,
     originalReference: transaction.interactionId,
-    reference: paymentObject.custom.fields.interfaceId
+    reference: paymentObject.custom.fields.merchantReference
   }
 
   const request = {

--- a/extension/src/paymentHandler/creditCard/credit-card-make-payment.handler.js
+++ b/extension/src/paymentHandler/creditCard/credit-card-make-payment.handler.js
@@ -85,7 +85,7 @@ async function _makePayment (paymentObject) {
       currency: transaction.amount.currencyCode,
       value: transaction.amount.centAmount
     },
-    reference: paymentObject.interfaceId,
+    reference: paymentObject.custom.fields.interfaceId,
     paymentMethod: {
       type: 'scheme',
       encryptedCardNumber: paymentObject.custom.fields.encryptedCardNumber,

--- a/extension/src/paymentHandler/creditCard/credit-card-make-payment.handler.js
+++ b/extension/src/paymentHandler/creditCard/credit-card-make-payment.handler.js
@@ -85,7 +85,7 @@ async function _makePayment (paymentObject) {
       currency: transaction.amount.currencyCode,
       value: transaction.amount.centAmount
     },
-    reference: paymentObject.custom.fields.interfaceId,
+    reference: paymentObject.custom.fields.merchantReference,
     paymentMethod: {
       type: 'scheme',
       encryptedCardNumber: paymentObject.custom.fields.encryptedCardNumber,

--- a/extension/src/paymentHandler/kcp/kcp-make-payment.handler.js
+++ b/extension/src/paymentHandler/kcp/kcp-make-payment.handler.js
@@ -56,7 +56,7 @@ async function _callAdyen (paymentObject) {
       currency: transaction.amount.currencyCode,
       value: transaction.amount.centAmount
     },
-    reference: paymentObject.custom.fields.interfaceId,
+    reference: paymentObject.custom.fields.merchantReference,
     paymentMethod: {
       type: paymentMethodType
     },

--- a/extension/src/paymentHandler/kcp/kcp-make-payment.handler.js
+++ b/extension/src/paymentHandler/kcp/kcp-make-payment.handler.js
@@ -56,7 +56,7 @@ async function _callAdyen (paymentObject) {
       currency: transaction.amount.currencyCode,
       value: transaction.amount.centAmount
     },
-    reference: paymentObject.interfaceId,
+    reference: paymentObject.custom.fields.interfaceId,
     paymentMethod: {
       type: paymentMethodType
     },

--- a/extension/src/paymentHandler/paypal/paypal-make-payment.handler.js
+++ b/extension/src/paymentHandler/paypal/paypal-make-payment.handler.js
@@ -56,7 +56,7 @@ async function _callAdyen (paymentObject) {
       currency: transaction.amount.currencyCode,
       value: transaction.amount.centAmount
     },
-    reference: paymentObject.custom.fields.interfaceId,
+    reference: paymentObject.custom.fields.merchantReference,
     paymentMethod: {
       type: 'paypal'
     },

--- a/extension/src/paymentHandler/paypal/paypal-make-payment.handler.js
+++ b/extension/src/paymentHandler/paypal/paypal-make-payment.handler.js
@@ -56,7 +56,7 @@ async function _callAdyen (paymentObject) {
       currency: transaction.amount.currencyCode,
       value: transaction.amount.centAmount
     },
-    reference: paymentObject.interfaceId,
+    reference: paymentObject.custom.fields.interfaceId,
     paymentMethod: {
       type: 'paypal'
     },

--- a/extension/src/validator/error-messages.js
+++ b/extension/src/validator/error-messages.js
@@ -9,7 +9,7 @@ module.exports = {
   MISSING_EXPIRY_YEAR: 'Set custom.fields.encryptedExpiryYear',
   MISSING_SECURITY_CODE: 'Set custom.fields.encryptedSecurityCode',
   MISSING_RETURN_URL: 'Set custom.fields.returnUrl',
-  MISSING_INTERFACE_ID: 'Set custom interfaceId',
+  MISSING_MERCHANT_REFERENCE: 'Set custom merchantReference',
   MISSING_PAYLOAD: 'Set custom.fields.payload',
   MISSING_PAYMENT_DATA: 'Set custom.fields.paymentData',
   MISSING_PARES: 'Set custom.fields.PaRes',

--- a/extension/src/validator/error-messages.js
+++ b/extension/src/validator/error-messages.js
@@ -9,7 +9,7 @@ module.exports = {
   MISSING_EXPIRY_YEAR: 'Set custom.fields.encryptedExpiryYear',
   MISSING_SECURITY_CODE: 'Set custom.fields.encryptedSecurityCode',
   MISSING_RETURN_URL: 'Set custom.fields.returnUrl',
-  MISSING_INTERFACE_ID: 'Set interfaceId',
+  MISSING_INTERFACE_ID: 'Set custom interfaceId',
   MISSING_PAYLOAD: 'Set custom.fields.payload',
   MISSING_PAYMENT_DATA: 'Set custom.fields.paymentData',
   MISSING_PARES: 'Set custom.fields.PaRes',

--- a/extension/src/validator/validator-builder.js
+++ b/extension/src/validator/validator-builder.js
@@ -90,10 +90,10 @@ function withPayment (paymentObject) {
         errors.hasReturnUrl = errorMessages.MISSING_RETURN_URL
       return this
     },
-    validateInterfaceIdField () {
-      const hasInterfaceId = !_.isEmpty(paymentObject.custom.fields.interfaceId)
-      if (!hasInterfaceId)
-        errors.hasInterfaceId = errorMessages.MISSING_INTERFACE_ID
+    validateMerchantReferenceField () {
+      const hasMerchantReference = !_.isEmpty(paymentObject.custom.fields.merchantReference)
+      if (!hasMerchantReference)
+        errors.hasMerchantReference = errorMessages.MISSING_MERCHANT_REFERENCE
       return this
     },
     validatePayloadField () {

--- a/extension/src/validator/validator-builder.js
+++ b/extension/src/validator/validator-builder.js
@@ -91,7 +91,7 @@ function withPayment (paymentObject) {
       return this
     },
     validateInterfaceIdField () {
-      const hasInterfaceId = !_.isEmpty(paymentObject.interfaceId)
+      const hasInterfaceId = !_.isEmpty(paymentObject.custom.fields.interfaceId)
       if (!hasInterfaceId)
         errors.hasInterfaceId = errorMessages.MISSING_INTERFACE_ID
       return this

--- a/extension/test/fixtures/ctp-payment.json
+++ b/extension/test/fixtures/ctp-payment.json
@@ -10,7 +10,6 @@
   "createdBy": {
     "clientId": "GfjD1YgZgpe0K6wEdUEpwTmx"
   },
-  "interfaceId": "paymentReferenceId",
   "amountPlanned": {
     "type": "centPrecision",
     "currencyCode": "EUR",
@@ -27,6 +26,7 @@
       "id": "3bb94fa2-6254-4a31-83e8-a2a882c15173"
     },
     "fields": {
+      "interfaceId": "paymentReferenceId",
       "redirectUrl": "redirectUrl",
       "redirectMethod": "redirectMethod",
       "returnUrl": "returnUrl",

--- a/extension/test/fixtures/ctp-payment.json
+++ b/extension/test/fixtures/ctp-payment.json
@@ -26,7 +26,7 @@
       "id": "3bb94fa2-6254-4a31-83e8-a2a882c15173"
     },
     "fields": {
-      "interfaceId": "paymentReferenceId",
+      "merchantReference": "paymentReferenceId",
       "redirectUrl": "redirectUrl",
       "redirectMethod": "redirectMethod",
       "returnUrl": "returnUrl",

--- a/extension/test/fixtures/payment-credit-card-3d.json
+++ b/extension/test/fixtures/payment-credit-card-3d.json
@@ -1,5 +1,4 @@
 {
-  "interfaceId":"paymentReferenceId",
   "amountPlanned": {
     "type": "centPrecision",
     "currencyCode": "EUR",
@@ -16,6 +15,7 @@
       "key": "ctp-adyen-integration-payment-custom-type"
     },
     "fields": {
+      "interfaceId": "paymentReferenceId",
       "countryCode": "DE",
       "encryptedCardNumber":"${encryptedCardNumber}",
       "encryptedExpiryMonth":"${encryptedExpiryMonth}",

--- a/extension/test/fixtures/payment-credit-card-3d.json
+++ b/extension/test/fixtures/payment-credit-card-3d.json
@@ -15,7 +15,7 @@
       "key": "ctp-adyen-integration-payment-custom-type"
     },
     "fields": {
-      "interfaceId": "paymentReferenceId",
+      "merchantReference": "paymentReferenceId",
       "countryCode": "DE",
       "encryptedCardNumber":"${encryptedCardNumber}",
       "encryptedExpiryMonth":"${encryptedExpiryMonth}",

--- a/extension/test/fixtures/payment-credit-card.json
+++ b/extension/test/fixtures/payment-credit-card.json
@@ -1,5 +1,4 @@
 {
-  "interfaceId":"paymentReferenceId",
   "amountPlanned": {
     "type": "centPrecision",
     "currencyCode": "EUR",
@@ -16,6 +15,7 @@
       "key": "ctp-adyen-integration-payment-custom-type"
     },
     "fields": {
+      "interfaceId": "paymentReferenceId",
       "countryCode": "DE",
       "encryptedCardNumber":"${encryptedCardNumber}",
       "encryptedExpiryMonth":"${encryptedExpiryMonth}",

--- a/extension/test/fixtures/payment-credit-card.json
+++ b/extension/test/fixtures/payment-credit-card.json
@@ -15,7 +15,7 @@
       "key": "ctp-adyen-integration-payment-custom-type"
     },
     "fields": {
-      "interfaceId": "paymentReferenceId",
+      "merchantReference": "paymentReferenceId",
       "countryCode": "DE",
       "encryptedCardNumber":"${encryptedCardNumber}",
       "encryptedExpiryMonth":"${encryptedExpiryMonth}",

--- a/extension/test/fixtures/payment-kcp.json
+++ b/extension/test/fixtures/payment-kcp.json
@@ -1,5 +1,4 @@
 {
-  "interfaceId":"paymentReferenceId",
   "amountPlanned": {
     "type": "centPrecision",
     "currencyCode": "EUR",
@@ -16,6 +15,7 @@
       "key": "ctp-adyen-integration-payment-custom-type"
     },
     "fields": {
+      "interfaceId": "paymentReferenceId",
       "returnUrl":"https://your-company.com/checkout/"
     }
   },

--- a/extension/test/fixtures/payment-kcp.json
+++ b/extension/test/fixtures/payment-kcp.json
@@ -15,7 +15,7 @@
       "key": "ctp-adyen-integration-payment-custom-type"
     },
     "fields": {
-      "interfaceId": "paymentReferenceId",
+      "merchantReference": "paymentReferenceId",
       "returnUrl":"https://your-company.com/checkout/"
     }
   },

--- a/extension/test/fixtures/payment-no-method.json
+++ b/extension/test/fixtures/payment-no-method.json
@@ -14,7 +14,7 @@
       "key": "ctp-adyen-integration-payment-custom-type"
     },
     "fields": {
-      "merchantReference": "pspReference",
+      "merchantReference": "paymentReferenceId",
       "countryCode": "DE"
     }
   },

--- a/extension/test/fixtures/payment-no-method.json
+++ b/extension/test/fixtures/payment-no-method.json
@@ -14,7 +14,7 @@
       "key": "ctp-adyen-integration-payment-custom-type"
     },
     "fields": {
-      "interfaceId": "pspReference",
+      "merchantReference": "pspReference",
       "countryCode": "DE"
     }
   },

--- a/extension/test/fixtures/payment-no-method.json
+++ b/extension/test/fixtures/payment-no-method.json
@@ -1,5 +1,4 @@
 {
-  "interfaceId": "pspReference",
   "amountPlanned": {
     "type": "centPrecision",
     "currencyCode": "EUR",
@@ -15,6 +14,7 @@
       "key": "ctp-adyen-integration-payment-custom-type"
     },
     "fields": {
+      "interfaceId": "pspReference",
       "countryCode": "DE"
     }
   },

--- a/extension/test/fixtures/payment-paypal.json
+++ b/extension/test/fixtures/payment-paypal.json
@@ -1,5 +1,4 @@
 {
-  "interfaceId":"paymentReferenceId",
   "amountPlanned": {
     "type": "centPrecision",
     "currencyCode": "EUR",
@@ -16,6 +15,7 @@
       "key": "ctp-adyen-integration-payment-custom-type"
     },
     "fields": {
+      "interfaceId":"paymentReferenceId",
       "returnUrl":"https://your-company.com/checkout/"
     }
   },

--- a/extension/test/fixtures/payment-paypal.json
+++ b/extension/test/fixtures/payment-paypal.json
@@ -15,7 +15,7 @@
       "key": "ctp-adyen-integration-payment-custom-type"
     },
     "fields": {
-      "interfaceId":"paymentReferenceId",
+      "merchantReference":"paymentReferenceId",
       "returnUrl":"https://your-company.com/checkout/"
     }
   },

--- a/extension/test/integration/credit-card-make-payment.handler.spec.js
+++ b/extension/test/integration/credit-card-make-payment.handler.spec.js
@@ -38,7 +38,7 @@ describe('credit card payment', () => {
 
     const adyenRequestBody = JSON.parse(adyenRequest.body)
     expect(adyenRequestBody.merchantAccount).to.be.equal(process.env.ADYEN_MERCHANT_ACCOUNT)
-    expect(adyenRequestBody.reference).to.be.equal(paymentTemplate.interfaceId)
+    expect(adyenRequestBody.reference).to.be.equal(paymentTemplate.custom.fields.interfaceId)
     expect(adyenRequestBody.returnUrl).to.be.equal(paymentTemplate.custom.fields.returnUrl)
     expect(adyenRequestBody.amount.currency).to.be.equal(paymentTemplate.transactions[0].amount.currencyCode)
     expect(adyenRequestBody.amount.value).to.be.equal(paymentTemplate.transactions[0].amount.centAmount)
@@ -75,7 +75,7 @@ describe('credit card payment', () => {
 
     const adyenRequestBody = JSON.parse(adyenRequest.body)
     expect(adyenRequestBody.merchantAccount).to.be.equal(process.env.ADYEN_MERCHANT_ACCOUNT)
-    expect(adyenRequestBody.reference).to.be.equal(paymentTemplate.interfaceId)
+    expect(adyenRequestBody.reference).to.be.equal(paymentTemplate.custom.fields.interfaceId)
     expect(adyenRequestBody.returnUrl).to.be.equal(`${process.env.API_EXTENSION_BASE_URL}/test-return-url`)
     expect(adyenRequestBody.amount.currency).to.be.equal(paymentTemplate.transactions[0].amount.currencyCode)
     expect(adyenRequestBody.amount.value).to.be.equal(paymentTemplate.transactions[0].amount.centAmount)

--- a/extension/test/integration/credit-card-make-payment.handler.spec.js
+++ b/extension/test/integration/credit-card-make-payment.handler.spec.js
@@ -38,7 +38,7 @@ describe('credit card payment', () => {
 
     const adyenRequestBody = JSON.parse(adyenRequest.body)
     expect(adyenRequestBody.merchantAccount).to.be.equal(process.env.ADYEN_MERCHANT_ACCOUNT)
-    expect(adyenRequestBody.reference).to.be.equal(paymentTemplate.custom.fields.interfaceId)
+    expect(adyenRequestBody.reference).to.be.equal(paymentTemplate.custom.fields.merchantReference)
     expect(adyenRequestBody.returnUrl).to.be.equal(paymentTemplate.custom.fields.returnUrl)
     expect(adyenRequestBody.amount.currency).to.be.equal(paymentTemplate.transactions[0].amount.currencyCode)
     expect(adyenRequestBody.amount.value).to.be.equal(paymentTemplate.transactions[0].amount.centAmount)
@@ -75,7 +75,7 @@ describe('credit card payment', () => {
 
     const adyenRequestBody = JSON.parse(adyenRequest.body)
     expect(adyenRequestBody.merchantAccount).to.be.equal(process.env.ADYEN_MERCHANT_ACCOUNT)
-    expect(adyenRequestBody.reference).to.be.equal(paymentTemplate.custom.fields.interfaceId)
+    expect(adyenRequestBody.reference).to.be.equal(paymentTemplate.custom.fields.merchantReference)
     expect(adyenRequestBody.returnUrl).to.be.equal(`${process.env.API_EXTENSION_BASE_URL}/test-return-url`)
     expect(adyenRequestBody.amount.currency).to.be.equal(paymentTemplate.transactions[0].amount.currencyCode)
     expect(adyenRequestBody.amount.value).to.be.equal(paymentTemplate.transactions[0].amount.centAmount)

--- a/extension/test/unit/payment.controller.spec.js
+++ b/extension/test/unit/payment.controller.spec.js
@@ -26,9 +26,9 @@ describe('Payment controller', () => {
       await paymentController.processRequest(mockRequest)
     })
 
-    it('on missing interface id should throw error', async () => {
+    it('on missing merchant reference should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.custom.fields.interfaceId = ''
+      ctpPaymentClone.custom.fields.merchantReference = ''
 
       utilsStub.collectRequestData = () => JSON.stringify({ resource: { obj: ctpPaymentClone } })
       utilsStub.sendResponse = ({ statusCode, data }) => {
@@ -36,7 +36,7 @@ describe('Payment controller', () => {
         expect(data).to.deep.equal({
           errors: [{
             code: 'InvalidField',
-            message: errorMessages.MISSING_INTERFACE_ID
+            message: errorMessages.MISSING_MERCHANT_REFERENCE
           }]
         })
       }
@@ -46,7 +46,7 @@ describe('Payment controller', () => {
 
     it('on wrong payment method should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.custom.fields = {"interfaceId": "paymentReferenceId"}
+      ctpPaymentClone.custom.fields = {"merchantReference": "paymentReferenceId"}
       ctpPaymentClone.paymentMethodInfo.method = 'wrong method'
 
       utilsStub.collectRequestData = () => JSON.stringify({ resource: { obj: ctpPaymentClone } })
@@ -65,7 +65,7 @@ describe('Payment controller', () => {
 
     it('on missing params for make paypal payment should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.custom.fields = {"interfaceId": "paymentReferenceId"}
+      ctpPaymentClone.custom.fields = {"merchantReference": "paymentReferenceId"}
       ctpPaymentClone.paymentMethodInfo.method = 'paypal'
       ctpPaymentClone.transactions[0].state = 'Initial'
 
@@ -85,7 +85,7 @@ describe('Payment controller', () => {
 
     it('on missing params for complete paypal payment should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.custom.fields = {"interfaceId": "paymentReferenceId"}
+      ctpPaymentClone.custom.fields = {"merchantReference": "paymentReferenceId"}
       ctpPaymentClone.paymentMethodInfo.method = 'paypal'
       ctpPaymentClone.transactions[0].state = 'Pending'
 
@@ -100,7 +100,7 @@ describe('Payment controller', () => {
 
     it('on missing params for make credit card payment should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.custom.fields = {"interfaceId": "paymentReferenceId"}
+      ctpPaymentClone.custom.fields = {"merchantReference": "paymentReferenceId"}
       ctpPaymentClone.paymentMethodInfo.method = 'creditCard'
       ctpPaymentClone.transactions[0].state = 'Initial'
 
@@ -137,7 +137,7 @@ describe('Payment controller', () => {
 
     it('on missing params for make 3ds payment should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.custom.fields = {"interfaceId": "paymentReferenceId"}
+      ctpPaymentClone.custom.fields = {"merchantReference": "paymentReferenceId"}
       ctpPaymentClone.paymentMethodInfo.method = 'creditCard_3d'
       ctpPaymentClone.transactions[0].state = 'Initial'
 
@@ -174,7 +174,7 @@ describe('Payment controller', () => {
 
     it('on missing params for complete credit card payment should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.custom.fields = {"interfaceId": "paymentReferenceId"}
+      ctpPaymentClone.custom.fields = {"merchantReference": "paymentReferenceId"}
       ctpPaymentClone.paymentMethodInfo.method = 'creditCard_3d'
       ctpPaymentClone.transactions[0].state = 'Pending'
 

--- a/extension/test/unit/payment.controller.spec.js
+++ b/extension/test/unit/payment.controller.spec.js
@@ -28,7 +28,7 @@ describe('Payment controller', () => {
 
     it('on missing interface id should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.interfaceId = ''
+      ctpPaymentClone.custom.fields.interfaceId = ''
 
       utilsStub.collectRequestData = () => JSON.stringify({ resource: { obj: ctpPaymentClone } })
       utilsStub.sendResponse = ({ statusCode, data }) => {
@@ -46,7 +46,7 @@ describe('Payment controller', () => {
 
     it('on wrong payment method should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.custom.fields = {}
+      ctpPaymentClone.custom.fields = {"interfaceId": "paymentReferenceId"}
       ctpPaymentClone.paymentMethodInfo.method = 'wrong method'
 
       utilsStub.collectRequestData = () => JSON.stringify({ resource: { obj: ctpPaymentClone } })
@@ -65,7 +65,7 @@ describe('Payment controller', () => {
 
     it('on missing params for make paypal payment should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.custom.fields = {}
+      ctpPaymentClone.custom.fields = {"interfaceId": "paymentReferenceId"}
       ctpPaymentClone.paymentMethodInfo.method = 'paypal'
       ctpPaymentClone.transactions[0].state = 'Initial'
 
@@ -85,7 +85,7 @@ describe('Payment controller', () => {
 
     it('on missing params for complete paypal payment should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.custom.fields = {}
+      ctpPaymentClone.custom.fields = {"interfaceId": "paymentReferenceId"}
       ctpPaymentClone.paymentMethodInfo.method = 'paypal'
       ctpPaymentClone.transactions[0].state = 'Pending'
 
@@ -100,7 +100,7 @@ describe('Payment controller', () => {
 
     it('on missing params for make credit card payment should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.custom.fields = {}
+      ctpPaymentClone.custom.fields = {"interfaceId": "paymentReferenceId"}
       ctpPaymentClone.paymentMethodInfo.method = 'creditCard'
       ctpPaymentClone.transactions[0].state = 'Initial'
 
@@ -137,7 +137,7 @@ describe('Payment controller', () => {
 
     it('on missing params for make 3ds payment should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.custom.fields = {}
+      ctpPaymentClone.custom.fields = {"interfaceId": "paymentReferenceId"}
       ctpPaymentClone.paymentMethodInfo.method = 'creditCard_3d'
       ctpPaymentClone.transactions[0].state = 'Initial'
 
@@ -174,7 +174,7 @@ describe('Payment controller', () => {
 
     it('on missing params for complete credit card payment should throw error', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.custom.fields = {}
+      ctpPaymentClone.custom.fields = {"interfaceId": "paymentReferenceId"}
       ctpPaymentClone.paymentMethodInfo.method = 'creditCard_3d'
       ctpPaymentClone.transactions[0].state = 'Pending'
 

--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -146,7 +146,7 @@ function getAddTransactionUpdateAction (type, state, amount, currency) {
 
 async function getPaymentByMerchantReference (merchantReference, ctpClient) {
   try {
-    const result = await ctpClient.fetch(ctpClient.builder.payments.where(`custom.fields.interfaceId="${merchantReference}"`))
+    const result = await ctpClient.fetch(ctpClient.builder.payments.where(`custom(fields(interfaceId="${merchantReference}"))`))
     return _.get(result, 'body.results[0]', null)
   } catch (err) {
     throw Error(`Failed to fetch a payment with merchantReference: ${merchantReference}. `

--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -37,7 +37,7 @@ async function updatePaymentWithRepeater (payment, notification, ctpClient) {
     try {
       /* eslint-disable-next-line no-await-in-loop */
       await ctpClient.update(ctpClient.builder.payments, currentPayment.id, currentVersion, updateActions)
-      logger.debug(`Payment with interfaceId ${currentPayment.custom.fields.interfaceId}`
+      logger.debug(`Payment with merchantReference ${currentPayment.custom.fields.merchantReference}`
         + 'was successfully updated')
       break
     } catch (err) {
@@ -146,7 +146,7 @@ function getAddTransactionUpdateAction (type, state, amount, currency) {
 
 async function getPaymentByMerchantReference (merchantReference, ctpClient) {
   try {
-    const result = await ctpClient.fetch(ctpClient.builder.payments.where(`custom(fields(interfaceId="${merchantReference}"))`))
+    const result = await ctpClient.fetch(ctpClient.builder.payments.where(`custom(fields(merchantReference="${merchantReference}"))`))
     return _.get(result, 'body.results[0]', null)
   } catch (err) {
     throw Error(`Failed to fetch a payment with merchantReference: ${merchantReference}. `

--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -37,7 +37,7 @@ async function updatePaymentWithRepeater (payment, notification, ctpClient) {
     try {
       /* eslint-disable-next-line no-await-in-loop */
       await ctpClient.update(ctpClient.builder.payments, currentPayment.id, currentVersion, updateActions)
-      logger.debug(`Payment with interfaceId ${currentPayment.interfaceId}`
+      logger.debug(`Payment with interfaceId ${currentPayment.custom.fields.interfaceId}`
         + 'was successfully updated')
       break
     } catch (err) {
@@ -146,7 +146,7 @@ function getAddTransactionUpdateAction (type, state, amount, currency) {
 
 async function getPaymentByMerchantReference (merchantReference, ctpClient) {
   try {
-    const result = await ctpClient.fetch(ctpClient.builder.payments.where(`interfaceId="${merchantReference}"`))
+    const result = await ctpClient.fetch(ctpClient.builder.payments.where(`custom.fields.interfaceId="${merchantReference}"`))
     return _.get(result, 'body.results[0]', null)
   } catch (err) {
     throw Error(`Failed to fetch a payment with merchantReference: ${merchantReference}. `

--- a/notification/test/integration/init/ensure-payment-custom-type.js
+++ b/notification/test/integration/init/ensure-payment-custom-type.js
@@ -1,0 +1,21 @@
+const paymentCustomType = require('../../resources/payment-custom-types.json')
+
+const utils = require('../../../src/utils/logger')
+
+const logger = utils.getLogger()
+
+async function ensurePaymentCustomType (ctpClient) {
+  try {
+    const { body } = await ctpClient.fetch(ctpClient.builder.types.where(`key="${paymentCustomType.key}"`))
+    if (body.results.length === 0) {
+      await ctpClient.create(ctpClient.builder.types, paymentCustomType)
+      logger.info('Successfully created payment custom type')
+    }
+  } catch (e) {
+    logger.error(e, 'Error when creating payment custom type, skipping...')
+  }
+}
+
+module.exports = {
+  ensurePaymentCustomType
+}

--- a/notification/test/integration/init/init-resources.js
+++ b/notification/test/integration/init/init-resources.js
@@ -1,10 +1,12 @@
 const {
   ensureInterfaceInteractionCustomType
 } = require('../../../src/config/init/ensure-interface-interaction-custom-type')
+const { ensurePaymentCustomType } = require('./ensure-payment-custom-type')
 const { ensurePayment } = require('./ensure-payment')
 
 async function ensureResources (ctpClient) {
   await ensureInterfaceInteractionCustomType(ctpClient)
+  await ensurePaymentCustomType(ctpClient)
   await ensurePayment(ctpClient)
 }
 

--- a/notification/test/resources/payment-credit-card.json
+++ b/notification/test/resources/payment-credit-card.json
@@ -18,7 +18,7 @@
     },
     "fields": {
       "countryCode": "DE",
-      "interfaceId":"paymentReferenceId",
+      "merchantReference":"paymentReferenceId",
       "encryptedCardNumber":"${encryptedCardNumber}",
       "encryptedExpiryMonth":"${encryptedExpiryMonth}",
       "encryptedExpiryYear":"${encryptedExpiryYear}",

--- a/notification/test/resources/payment-credit-card.json
+++ b/notification/test/resources/payment-credit-card.json
@@ -1,7 +1,6 @@
 {
   "id": "123212321",
   "version": "2",
-  "interfaceId":"paymentReferenceId",
   "amountPlanned": {
     "type": "centPrecision",
     "currencyCode": "EUR",
@@ -19,6 +18,7 @@
     },
     "fields": {
       "countryCode": "DE",
+      "interfaceId":"paymentReferenceId",
       "encryptedCardNumber":"${encryptedCardNumber}",
       "encryptedExpiryMonth":"${encryptedExpiryMonth}",
       "encryptedExpiryYear":"${encryptedExpiryYear}",

--- a/notification/test/resources/payment-custom-types.json
+++ b/notification/test/resources/payment-custom-types.json
@@ -11,6 +11,17 @@
       "type": {
         "name": "String"
       },
+      "name": "interfaceId",
+      "label": {
+        "en": "interfaceId"
+      },
+      "required": true,
+      "inputHint": "SingleLine"
+    },
+    {
+      "type": {
+        "name": "String"
+      },
       "name": "payload",
       "label": {
         "en": "payload"

--- a/notification/test/resources/payment-custom-types.json
+++ b/notification/test/resources/payment-custom-types.json
@@ -11,9 +11,9 @@
       "type": {
         "name": "String"
       },
-      "name": "interfaceId",
+      "name": "merchantReference",
       "label": {
-        "en": "interfaceId"
+        "en": "merchantReference"
       },
       "required": true,
       "inputHint": "SingleLine"

--- a/notification/test/resources/payment-draft.json
+++ b/notification/test/resources/payment-draft.json
@@ -1,11 +1,18 @@
 {
   "key": "test-payment",
-  "interfaceId": "8313842560770001",
   "amountPlanned": {
     "type": "centPrecision",
     "currencyCode": "EUR",
     "centAmount": 795,
     "fractionDigits": 2
+  },
+  "custom": {
+    "type": {
+      "key": "ctp-adyen-integration-payment-custom-type"
+    },
+    "fields": {
+      "interfaceId": "8313842560770001"
+    }
   },
   "transactions": [
     {

--- a/notification/test/resources/payment-draft.json
+++ b/notification/test/resources/payment-draft.json
@@ -11,7 +11,7 @@
       "key": "ctp-adyen-integration-payment-custom-type"
     },
     "fields": {
-      "interfaceId": "8313842560770001"
+      "merchantReference": "8313842560770001"
     }
   },
   "transactions": [


### PR DESCRIPTION
This resolves #62 

This work should change the reference field from interfaceId to a custom field specified on the payment object. If you could give some feedback on whether this is the correct approach, that'd be great. If you want the name of the field to be different too, I can make that change.

All the unit tests past, one test fails but that seems to be failing on master too right now so it seems to be unrelated.