### PR TITLE
Fix potential error with merchantReference validation

### DIFF
--- a/extension/src/validator/validator-builder.js
+++ b/extension/src/validator/validator-builder.js
@@ -91,7 +91,9 @@ function withPayment (paymentObject) {
       return this
     },
     validateMerchantReferenceField () {
-      const hasMerchantReference = !_.isEmpty(paymentObject.custom.fields.merchantReference)
+      const hasMerchantReference = _.isObject(paymentObject.custom)
+        && _.isObject(paymentObject.custom.fields)
+        && !_.isEmpty(paymentObject.custom.fields.merchantReference)
       if (!hasMerchantReference)
         errors.hasMerchantReference = errorMessages.MISSING_MERCHANT_REFERENCE
       return this

--- a/extension/test/unit/validator-builder.spec.js
+++ b/extension/test/unit/validator-builder.spec.js
@@ -1,0 +1,27 @@
+const _ = require('lodash')
+const { expect } = require('chai')
+var async = require('async')
+
+const ValidatorBuilder = require('../../src/validator/validator-builder')
+
+describe('Validator builder', () => {
+
+  let vb = ValidatorBuilder.withPayment({})
+
+  async.each(
+    [vb.validateEncryptedCardNumberField,
+    vb.validateEncryptedExpiryMonthField,
+    vb.validateEncryptedExpiryYearField,
+    vb.validateEncryptedSecurityCodeField,
+    vb.validateReturnUrlField,
+    vb.validateMerchantReferenceField,
+    vb.validatePayloadField,
+    vb.validatePaymentDataField,
+    vb.validatePaResField,
+    vb.validateMdField],
+    function(validation) {
+    it('on empty payment object validation for ' + validation.name + ' to not throw exception', async () => {
+      expect(validation).to.not.throw()
+    })
+  })
+})

--- a/extension/test/unit/validator-builder.spec.js
+++ b/extension/test/unit/validator-builder.spec.js
@@ -1,27 +1,27 @@
 const _ = require('lodash')
 const { expect } = require('chai')
-var async = require('async')
+const async = require('async')
 
 const ValidatorBuilder = require('../../src/validator/validator-builder')
 
 describe('Validator builder', () => {
-
-  let vb = ValidatorBuilder.withPayment({})
+  const vb = ValidatorBuilder.withPayment({})
 
   async.each(
     [vb.validateEncryptedCardNumberField,
-    vb.validateEncryptedExpiryMonthField,
-    vb.validateEncryptedExpiryYearField,
-    vb.validateEncryptedSecurityCodeField,
-    vb.validateReturnUrlField,
-    vb.validateMerchantReferenceField,
-    vb.validatePayloadField,
-    vb.validatePaymentDataField,
-    vb.validatePaResField,
-    vb.validateMdField],
-    function(validation) {
-    it('on empty payment object validation for ' + validation.name + ' to not throw exception', async () => {
-      expect(validation).to.not.throw()
-    })
-  })
+      vb.validateEncryptedExpiryMonthField,
+      vb.validateEncryptedExpiryYearField,
+      vb.validateEncryptedSecurityCodeField,
+      vb.validateReturnUrlField,
+      vb.validateMerchantReferenceField,
+      vb.validatePayloadField,
+      vb.validatePaymentDataField,
+      vb.validatePaResField,
+      vb.validateMdField],
+    (validation) => {
+      it(`on empty payment object validation for ${validation.name} to not throw exception`, async () => {
+        expect(validation).to.not.throw()
+      })
+    }
+  )
 })


### PR DESCRIPTION
Do more checks to ensure the underlying objects exist before checking that the merchantReference field isn't empty