### PR TITLE
Restrict client scope

### DIFF
--- a/notification/src/utils/ctp.js
+++ b/notification/src/utils/ctp.js
@@ -17,7 +17,7 @@ function createCtpClient (config, extraScopes) {
 
   let scopeBuilder = [scopes.MANAGE_PAYMENTS.concat(':').concat(projectKey)]
   if (config.ensureResources) scopeBuilder = scopeBuilder.concat(scopes.MANAGE_TYPES.concat(':').concat(projectKey))
-  if (extraScopes) scopeBuilder = scopeBuilder.concat('manage_extensions:'.concat(projectKey))
+  if (extraScopes) scopeBuilder = scopeBuilder.concat(extraScopes)
 
   const authMiddleware = createAuthMiddlewareForClientCredentialsFlow({
     host: AUTH_HOST,

--- a/notification/test/integration/notification.handler.spec.js
+++ b/notification/test/integration/notification.handler.spec.js
@@ -12,7 +12,7 @@ const notifications = require('../resources/notification')
 const localhostIp = address()
 
 describe('notification module', () => {
-  const ctpClient = ctpClientBuilder.get(config)
+  const ctpClient = ctpClientBuilder.get(config, ['manage_extensions:'.concat(config.ctp.projectKey)])
 
   before(async () => {
     await iTSetUp.startServer()


### PR DESCRIPTION
This PR will restrict the scope that the notification module uses to request client credentials to only what is required instead of always using manage_project for everything. Security best practice means we should not be providing all access tokens to services that don't need them.

This code will always grant `manage_payments`, will grant `manage_types` if `ENSURE_RESOURCES` isn't set to `false` and will grant `manage_extensions` when running integration tests so that they can perform their destroy and create of the ngrok based extension before running each test.

This code will be a breaking change for any deployments that currently use `manage_project` scope as commercetools will not let you request a lesser scope such as `manage_payments` if your token was created with `manage_project`.

As always, please let me know if there's anything that needs changing/adding!