### PR TITLE
Remove obsolete data from interface interactions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_deploy:
 after_deploy:
   - docker logout
 
+# cypress test fails without libgconf-2-4 package
+# see https://github.com/cypress-io/cypress/issues/4069
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,11 @@ before_deploy:
 after_deploy:
   - docker logout
 
+addons:
+  apt:
+    packages:
+    - libgconf-2-4
+
 deploy:
   - provider: script
     script: bash ./travis-build.sh "$TEST_DIR"

--- a/extension/src/paymentHandler/payment-utils.js
+++ b/extension/src/paymentHandler/payment-utils.js
@@ -68,7 +68,7 @@ function createAddInterfaceInteractionAction (
     fields: {
       createdAt: new Date(),
       response: JSON.stringify(response),
-      request: JSON.stringify(request),
+      request: JSON.stringify(request.body),
       type,
       status
     }

--- a/extension/test/integration/cancel-or-refund.handler.spec.js
+++ b/extension/test/integration/cancel-or-refund.handler.spec.js
@@ -52,7 +52,7 @@ describe('Cancel or refund', () => {
 
     const interfaceInteractionFields = updatedPayment.interfaceInteractions[1].fields
     const adyenRequest = JSON.parse(interfaceInteractionFields.request)
-    const adyenRequestBody = JSON.parse(adyenRequest.body)
+    const adyenRequestBody = JSON.parse(adyenRequest)
     expect(adyenRequestBody.originalReference).to.equal(chargeTransaction.interactionId)
 
     const adyenResponse = JSON.parse(interfaceInteractionFields.response)

--- a/extension/test/integration/cancel-or-refund.handler.spec.js
+++ b/extension/test/integration/cancel-or-refund.handler.spec.js
@@ -51,8 +51,8 @@ describe('Cancel or refund', () => {
     expect(refundTransaction.state).to.equal('Pending')
 
     const interfaceInteractionFields = updatedPayment.interfaceInteractions[1].fields
-    const adyenRequest = JSON.parse(interfaceInteractionFields.request)
-    const adyenRequestBody = JSON.parse(adyenRequest)
+    //interfaceInteractionFields.request is a stringify json
+    const adyenRequestBody = JSON.parse(JSON.parse(interfaceInteractionFields.request))
     expect(adyenRequestBody.originalReference).to.equal(chargeTransaction.interactionId)
 
     const adyenResponse = JSON.parse(interfaceInteractionFields.response)

--- a/extension/test/integration/credit-card-make-payment.handler.spec.js
+++ b/extension/test/integration/credit-card-make-payment.handler.spec.js
@@ -69,9 +69,8 @@ describe('credit card payment', () => {
     })
 
     const response = await ctpClient.create(ctpClient.builder.payments, JSON.parse(paymentDraft))
-    const adyenRequest = JSON.parse(response.body.interfaceInteractions[0].fields.request)
 
-    const adyenRequestBody = JSON.parse(adyenRequest)
+    const adyenRequestBody = JSON.parse(JSON.parse(response.body.interfaceInteractions[0].fields.request))
     expect(adyenRequestBody.merchantAccount).to.be.equal(process.env.ADYEN_MERCHANT_ACCOUNT)
     expect(adyenRequestBody.reference).to.be.equal(paymentTemplate.custom.fields.merchantReference)
     expect(adyenRequestBody.returnUrl).to.be.equal(`${process.env.API_EXTENSION_BASE_URL}/test-return-url`)

--- a/extension/test/integration/credit-card-make-payment.handler.spec.js
+++ b/extension/test/integration/credit-card-make-payment.handler.spec.js
@@ -34,9 +34,8 @@ describe('credit card payment', () => {
     const response = await ctpClient.create(ctpClient.builder.payments, JSON.parse(paymentDraft))
     expect(response.statusCode).to.equal(201)
     const adyenRequest = JSON.parse(response.body.interfaceInteractions[0].fields.request)
-    expect(adyenRequest.headers['x-api-key']).to.be.equal(process.env.ADYEN_API_KEY)
 
-    const adyenRequestBody = JSON.parse(adyenRequest.body)
+    const adyenRequestBody = JSON.parse(adyenRequest)
     expect(adyenRequestBody.merchantAccount).to.be.equal(process.env.ADYEN_MERCHANT_ACCOUNT)
     expect(adyenRequestBody.reference).to.be.equal(paymentTemplate.custom.fields.merchantReference)
     expect(adyenRequestBody.returnUrl).to.be.equal(paymentTemplate.custom.fields.returnUrl)
@@ -71,9 +70,8 @@ describe('credit card payment', () => {
 
     const response = await ctpClient.create(ctpClient.builder.payments, JSON.parse(paymentDraft))
     const adyenRequest = JSON.parse(response.body.interfaceInteractions[0].fields.request)
-    expect(adyenRequest.headers['x-api-key']).to.be.equal(process.env.ADYEN_API_KEY)
 
-    const adyenRequestBody = JSON.parse(adyenRequest.body)
+    const adyenRequestBody = JSON.parse(adyenRequest)
     expect(adyenRequestBody.merchantAccount).to.be.equal(process.env.ADYEN_MERCHANT_ACCOUNT)
     expect(adyenRequestBody.reference).to.be.equal(paymentTemplate.custom.fields.merchantReference)
     expect(adyenRequestBody.returnUrl).to.be.equal(`${process.env.API_EXTENSION_BASE_URL}/test-return-url`)
@@ -110,9 +108,8 @@ describe('credit card payment', () => {
     expect(ctpPayment.interfaceInteractions[0].fields.status).to.equal(c.FAILURE)
 
     const adyenRequest = JSON.parse(ctpPayment.interfaceInteractions[0].fields.request)
-    expect(adyenRequest.headers['x-api-key']).to.be.equal(process.env.ADYEN_API_KEY)
 
-    const adyenRequestBody = JSON.parse(adyenRequest.body)
+    const adyenRequestBody = JSON.parse(adyenRequest)
     expect(adyenRequestBody.merchantAccount).to.be.equal(process.env.ADYEN_MERCHANT_ACCOUNT)
     expect(adyenRequestBody.returnUrl).to.be.equal(paymentTemplate.custom.fields.returnUrl)
     expect(adyenRequestBody.amount.currency).to.be.equal(paymentTemplate.transactions[0].amount.currencyCode)

--- a/extension/test/integration/fetch-payment-method.handler.spec.js
+++ b/extension/test/integration/fetch-payment-method.handler.spec.js
@@ -25,9 +25,8 @@ describe('fetch payment', () => {
     const interfaceInteractionFields = response.body.interfaceInteractions[0].fields
     expect(interfaceInteractionFields.type).to.be.equal('getAvailablePaymentMethods')
     const adyenRequest = JSON.parse(interfaceInteractionFields.request)
-    expect(adyenRequest.headers['x-api-key']).to.be.equal(process.env.ADYEN_API_KEY)
 
-    const adyenRequestBody = JSON.parse(adyenRequest.body)
+    const adyenRequestBody = JSON.parse(adyenRequest)
     expect(adyenRequestBody.merchantAccount).to.be.equal(process.env.ADYEN_MERCHANT_ACCOUNT)
     expect(adyenRequestBody.countryCode).to.be.equal(paymentTemplate.custom.fields.countryCode)
     expect(adyenRequestBody.amount.currency).to.be.equal(paymentTemplate.amountPlanned.currencyCode)

--- a/extension/test/integration/fetch-payment-method.handler.spec.js
+++ b/extension/test/integration/fetch-payment-method.handler.spec.js
@@ -24,9 +24,8 @@ describe('fetch payment', () => {
 
     const interfaceInteractionFields = response.body.interfaceInteractions[0].fields
     expect(interfaceInteractionFields.type).to.be.equal('getAvailablePaymentMethods')
-    const adyenRequest = JSON.parse(interfaceInteractionFields.request)
 
-    const adyenRequestBody = JSON.parse(adyenRequest)
+    const adyenRequestBody = JSON.parse(JSON.parse(interfaceInteractionFields.request))
     expect(adyenRequestBody.merchantAccount).to.be.equal(process.env.ADYEN_MERCHANT_ACCOUNT)
     expect(adyenRequestBody.countryCode).to.be.equal(paymentTemplate.custom.fields.countryCode)
     expect(adyenRequestBody.amount.currency).to.be.equal(paymentTemplate.amountPlanned.currencyCode)

--- a/extension/test/integration/kcp-make-payment.spec.js
+++ b/extension/test/integration/kcp-make-payment.spec.js
@@ -22,8 +22,6 @@ describe('kcp make payment', () => {
     const response = await ctpClient.create(ctpClient.builder.payments, paymentDraft)
 
     expect(response.statusCode).to.equal(201)
-    const adyenRequest = JSON.parse(response.body.interfaceInteractions[0].fields.request)
-    expect(adyenRequest.headers['x-api-key']).to.be.equal(process.env.ADYEN_API_KEY)
     expect(response.body.custom.fields.redirectMethod).to.equal('GET')
     expect(response.body.custom.fields.redirectUrl).to.exist
   })

--- a/extension/test/integration/paypal-redirect-shopper.handler.spec.js
+++ b/extension/test/integration/paypal-redirect-shopper.handler.spec.js
@@ -22,8 +22,6 @@ describe('Paypal payment', () => {
     const response = await ctpClient.create(ctpClient.builder.payments, paymentDraft)
 
     expect(response.statusCode).to.equal(201)
-    const adyenRequest = JSON.parse(response.body.interfaceInteractions[0].fields.request)
-    expect(adyenRequest.headers['x-api-key']).to.be.equal(process.env.ADYEN_API_KEY)
     expect(response.body.custom.fields.redirectMethod).to.equal('GET')
     expect(response.body.custom.fields.redirectUrl).to.exist
   })

--- a/notification/README.md
+++ b/notification/README.md
@@ -20,15 +20,6 @@ Adyen sends notifications which look like this:
   "notificationItems": [
     {
       "NotificationRequestItem": {
-        "additionalData": {
-          "expiryDate": "12\/2012",
-          " NAME1 ": "VALUE1",
-          "authCode": "1234",
-          "cardSummary": "7777",
-          "totalFraudScore": "10",
-          "NAME2": "  VALUE2  ",
-          "fraudCheck-6-ShopperIpUsage": "10"
-        },
         "amount": {
           "currency": "EUR",
           "value": 10100
@@ -44,7 +35,6 @@ Adyen sends notifications which look like this:
         ],
         "paymentMethod": "visa",
         "pspReference": "test_AUTHORISATION_1",
-        "reason": "1234:7777:12\/2012",
         "success": "true"
       }
     }

--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -97,6 +97,7 @@ function calculateUpdateActionsForPayment (payment, notification) {
 }
 
 function getAddInterfaceInteractionUpdateAction (notification) {
+  // strip away sensitive data
   delete notification.additionalData
   delete notification.reason
 

--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -97,6 +97,9 @@ function calculateUpdateActionsForPayment (payment, notification) {
 }
 
 function getAddInterfaceInteractionUpdateAction (notification) {
+  delete notification.additionalData
+  delete notification.reason
+
   return {
     action: 'addInterfaceInteraction',
     type: {

--- a/notification/test/resources/notification.json
+++ b/notification/test/resources/notification.json
@@ -3,15 +3,6 @@
   "notificationItems": [
     {
       "NotificationRequestItem": {
-        "additionalData": {
-          "expiryDate": "12\/2012",
-          " NAME1 ": "VALUE1",
-          "authCode": "1234",
-          "cardSummary": "7777",
-          "totalFraudScore": "10",
-          "NAME2": "  VALUE2  ",
-          "fraudCheck-6-ShopperIpUsage": "10"
-        },
         "amount": {
           "currency": "EUR",
           "value": 10100
@@ -27,7 +18,6 @@
         ],
         "paymentMethod": "visa",
         "pspReference": "test_AUTHORISATION_1",
-        "reason": "1234:7777:12\/2012",
         "success": "true"
       }
     }


### PR DESCRIPTION
Related Issue: #63 

#### Extensions: 
- [x] Only store request body without header (which has adyen token in it): 7cc6018

#### Notification:
- [x] Remove additional `additionalData` and `reason` from notification requests/responses: 0dff86b 


**Note**: cypress was not working in Travis for this I needed to update travis.yml: 95cd24c
Details: https://github.com/cypress-io/cypress/issues/4069
