### PR TITLE
#63 delete obsolete `additionalData` from payment response which is store…

### DIFF
--- a/extension/src/paymentHandler/payment-utils.js
+++ b/extension/src/paymentHandler/payment-utils.js
@@ -62,6 +62,9 @@ function createAddInterfaceInteractionAction (
     request, response, type, status
   }
 ) {
+  // strip away sensitive data
+  delete response.additionalData
+
   return {
     action: 'addInterfaceInteraction',
     type: { key: c.CTP_INTERFACE_INTERACTION },

--- a/extension/test/integration/cancel-or-refund.handler.spec.js
+++ b/extension/test/integration/cancel-or-refund.handler.spec.js
@@ -57,5 +57,6 @@ describe('Cancel or refund', () => {
 
     const adyenResponse = JSON.parse(interfaceInteractionFields.response)
     expect(adyenResponse.response).to.equal('[cancelOrRefund-received]')
+    expect(adyenResponse.additionalData).to.not.exist
   })
 })

--- a/extension/test/integration/credit-card-make-payment.handler.spec.js
+++ b/extension/test/integration/credit-card-make-payment.handler.spec.js
@@ -49,6 +49,7 @@ describe('credit card payment', () => {
 
     const adyenResponse = JSON.parse(response.body.interfaceInteractions[0].fields.response)
     expect(adyenResponse.resultCode).to.be.equal('Authorised')
+    expect(adyenResponse.additionalData).to.not.exist
 
     const { transactions } = response.body
     expect(transactions).to.have.lengthOf(1)
@@ -91,6 +92,7 @@ describe('credit card payment', () => {
     expect(adyenResponse.redirect.data.MD).to.exist
     expect(adyenResponse.redirect.method).to.exist
     expect(adyenResponse.redirect.url).to.exist
+    expect(adyenResponse.additionalData).to.not.exist
   })
 
   it('on wrong credit card number, should log error to interface interaction', async () => {
@@ -128,6 +130,7 @@ describe('credit card payment', () => {
     expect(transaction.interactionId).to.be.undefined
     expect(transaction.type).to.equal('Authorization')
     expect(transaction.state).to.equal('Initial')
+    expect(adyenResponse.additionalData).to.not.exist
 
     const response2 = await ctpClient.update(ctpClient.builder.payments,
       ctpPayment.id, ctpPayment.version, [

--- a/extension/test/integration/fetch-payment-method.handler.spec.js
+++ b/extension/test/integration/fetch-payment-method.handler.spec.js
@@ -34,5 +34,6 @@ describe('fetch payment', () => {
     const adyenResponse = JSON.parse(interfaceInteractionFields.response)
     expect(adyenResponse.groups).to.be.an.instanceof(Array)
     expect(adyenResponse.paymentMethods).to.be.an.instanceof(Array)
+    expect(adyenResponse.additionalData).to.not.exist
   })
 })

--- a/extension/test/integration/kcp-make-payment.spec.js
+++ b/extension/test/integration/kcp-make-payment.spec.js
@@ -24,5 +24,10 @@ describe('kcp make payment', () => {
     expect(response.statusCode).to.equal(201)
     expect(response.body.custom.fields.redirectMethod).to.equal('GET')
     expect(response.body.custom.fields.redirectUrl).to.exist
+
+    const adyenResponse = JSON.parse(response.body.interfaceInteractions[0].fields.response)
+    expect(adyenResponse.redirect.method).to.exist
+    expect(adyenResponse.redirect.url).to.exist
+    expect(adyenResponse.additionalData).to.not.exist
   })
 })

--- a/extension/test/integration/paypal-redirect-shopper.handler.spec.js
+++ b/extension/test/integration/paypal-redirect-shopper.handler.spec.js
@@ -24,5 +24,10 @@ describe('Paypal payment', () => {
     expect(response.statusCode).to.equal(201)
     expect(response.body.custom.fields.redirectMethod).to.equal('GET')
     expect(response.body.custom.fields.redirectUrl).to.exist
+
+    const adyenResponse = JSON.parse(response.body.interfaceInteractions[0].fields.response)
+    expect(adyenResponse.redirect.method).to.exist
+    expect(adyenResponse.redirect.url).to.exist
+    expect(adyenResponse.additionalData).to.not.exists
   })
 })

--- a/extension/test/integration/paypal-redirect-shopper.handler.spec.js
+++ b/extension/test/integration/paypal-redirect-shopper.handler.spec.js
@@ -28,6 +28,6 @@ describe('Paypal payment', () => {
     const adyenResponse = JSON.parse(response.body.interfaceInteractions[0].fields.response)
     expect(adyenResponse.redirect.method).to.exist
     expect(adyenResponse.redirect.url).to.exist
-    expect(adyenResponse.additionalData).to.not.exists
+    expect(adyenResponse.additionalData).to.not.exist
   })
 })


### PR DESCRIPTION
delete obsolete `additionalData` from payment response which is stored ininterface Interactions.fields.

related issue: #63 

This field contains additional data, which may be required to return in a particular payment response. To choose data fields to be returned, go to Customer Area > Account > API URLs.
So it depends on your setting for the additional data. Now we should not store this data in interface interactions fields.

<img width="611" alt="Screenshot 2019-12-19 at 11 48 23" src="https://user-images.githubusercontent.com/3469524/71167721-7d6bc200-2255-11ea-8fe7-d4a65379f5c9.png">
