### PR TITLE
extension/src/lambda.js - handle nulls correctly

### DIFF
--- a/extension/src/lambda.js
+++ b/extension/src/lambda.js
@@ -9,8 +9,8 @@ exports.handler = async function (event) {
 
     return {
       responseType: paymentResult.success ? 'UpdateRequest' : 'FailedValidation',
-      errors: paymentResult.data.errors,
-      actions: paymentResult.data.actions
+      errors: paymentResult.data ? paymentResult.data.errors : undefined,
+      actions: paymentResult.data ? paymentResult.data.actions : undefined
     }
   } catch (e) {
     logger.error(e, `Unexpected error when processing event ${JSON.stringify(event)}`)

--- a/extension/test/unit/lambda.spec.js
+++ b/extension/test/unit/lambda.spec.js
@@ -40,6 +40,16 @@ describe('Lambda handler', () => {
     expect(result.actions).to.equal(undefined)
   })
 
+  it('does not throw unhandled exception when handlePayment data is null', async () => {
+    sinon.stub(paymentHandler, 'handlePayment').returns({ success: true, data: null })
+
+    const result = await handler(event)
+
+    expect(result.responseType).equals('UpdateRequest')
+    expect(result.errors).equals(undefined)
+    expect(result.actions).to.equal(undefined)
+  })
+
   it('logs and throws unhandled exceptions', async () => {
     const logSpy = sinon.spy()
     utils.getLogger().error = logSpy


### PR DESCRIPTION
Null check around `paymentResult.data`, which can be null if `paymentHandler` short circuits when not an adyen payment