### PR TITLE
use official node alpine image and update from node 8 to node 12.18.0 LTS

### DIFF
--- a/extension/Dockerfile
+++ b/extension/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:8
+FROM node:12.18.0-alpine
 MAINTAINER Professional Services <ps-dev@commercetools.de>
 
 WORKDIR /app

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "commercetools-adyen-integration",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commercetools-adyen-integration",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Integration between Commercetools and Adyen payment service provider",
   "license": "MIT",
   "scripts": {

--- a/notification/Dockerfile
+++ b/notification/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:8
+FROM node:12.18.0-alpine
 MAINTAINER Professional Services <ps-dev@commercetools.de>
 
 WORKDIR /app

--- a/notification/package-lock.json
+++ b/notification/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "commercetools-adyen-integration",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/notification/package.json
+++ b/notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commercetools-adyen-integration",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Part of the integration of Adyen with commercetools responsible to receive and process notifications from Adyen",
   "scripts": {
     "test": "npm run unit && npm run integration",


### PR DESCRIPTION
#209 

Image size are not changed much, it was 146 MB now it's 163 MB (because nodejs 12 image size is bigger than nodejs 8)

https://nodejs.org/en/about/releases/
https://hub.docker.com/_/node/

<img width="730" alt="Screenshot 2020-06-03 at 10 43 30" src="https://user-images.githubusercontent.com/3469524/83615634-1b92e080-a587-11ea-9822-fc43201a8d88.png">

