### PR TITLE
fix: return empty actions when paymentHandler short-circuits

### DIFF
--- a/extension/src/lambda.js
+++ b/extension/src/lambda.js
@@ -9,10 +9,9 @@ exports.handler = async function (event) {
 
     return {
       responseType: paymentResult.success ? 'UpdateRequest' : 'FailedValidation',
-      // Null check around paymentResult.data,
-      // which can be null if paymentHandler short circuits when not an adyen payment
+      // paymentResult.data can be null when paymentHandler short-circuits on non-Adyen payment
       errors: paymentResult.data ? paymentResult.data.errors : undefined,
-      actions: paymentResult.data ? paymentResult.data.actions : undefined
+      actions: paymentResult.data ? paymentResult.data.actions : []
     }
   } catch (e) {
     logger.error(e, `Unexpected error when processing event ${JSON.stringify(event)}`)

--- a/extension/test/unit/lambda.spec.js
+++ b/extension/test/unit/lambda.spec.js
@@ -47,7 +47,7 @@ describe('Lambda handler', () => {
 
     expect(result.responseType).equals('UpdateRequest')
     expect(result.errors).equals(undefined)
-    expect(result.actions).to.equal(undefined)
+    expect(result.actions).to.be.empty
   })
 
   it('logs and throws unhandled exceptions', async () => {


### PR DESCRIPTION
The response from a API Extension hosted in an AWS Lambda must contain a valid array for the `actions` property - i.e. undefined is not allowed

(This is an addition to a previous PR: https://github.com/commercetools/commercetools-adyen-integration/pull/297)