### PR TITLE
Concatenate obtained data before resolving promise

### DIFF
--- a/extension/src/utils.js
+++ b/extension/src/utils.js
@@ -14,7 +14,8 @@ function collectRequestData (request) {
     })
 
     request.on('end', () => {
-      resolve(data)
+      const dataStr = Buffer.concat(data).toString()
+      resolve(dataStr)
     })
   })
 }

--- a/notification/src/utils/commons.js
+++ b/notification/src/utils/commons.js
@@ -7,7 +7,8 @@ function collectRequestData (request) {
     })
 
     request.on('end', () => {
-      resolve(data)
+      const dataStr = Buffer.concat(data).toString()
+      resolve(dataStr)
     })
   })
 }


### PR DESCRIPTION
When data comes in chunks then it is stored into an array.
It should be concatenated to reflect incoming data as a whole.

It behaves strangely when more than one chunk of data appears. `data` variable is somehow concatenated by comma(sic!) and breaks incoming JSON structure if comma appears in vulnerable part of JSON (e.g. after backslash `\,"`).

String concatenation is prepared according to following nodejs guide:
https://nodejs.org/es/docs/guides/anatomy-of-an-http-transaction/#put-it-all-together