### PR TITLE
#461 Prevent on payment creation inconsistent amounts provided on makePaymentRequest and amountPlaned

### DIFF
--- a/extension/.eslintrc
+++ b/extension/.eslintrc
@@ -22,6 +22,7 @@
     "template-curly-spacing" : "off",
     "indent": "off",
     "operator-linebreak": "off",
-    "no-await-in-loop": "off"
+    "no-await-in-loop": "off",
+    "prefer-destructuring": "off"
   }
 }

--- a/extension/docs/WebComponentsIntegrationGuide.md
+++ b/extension/docs/WebComponentsIntegrationGuide.md
@@ -226,6 +226,7 @@ the Adyen Web Components will generate a `makePaymentRequest`.
 **Restrictions:**
 - `makePaymentRequest` must have a unique `reference` value for every payment object created in commercetools. Reference may only contain alphanumeric characters, underscores and hyphens and must have a minimum length of 2 characters and a maximum length of 80 characters.
 - `payment.amountPlanned` CANNOT be changed if there is `makePayment` interface interaction present in the payment.
+ If there is no `makePayment` interface interaction and `makePaymentRequest` custom field is added, `amount` value in this field must have the same value as `payment.amountPlanned`.
 This ensures eventual payment amount manipulations (i.e.: when [my-payments](https://docs.commercetools.com/http-api-projects-me-payments#my-payments) are used) for already initiated payment.
 
 

--- a/extension/src/validator/error-messages.js
+++ b/extension/src/validator/error-messages.js
@@ -4,6 +4,7 @@ module.exports = {
   MAKE_PAYMENT_REQUEST_INVALID_JSON: 'makePaymentRequest does not contain valid JSON.',
   // eslint-disable-next-line max-len
   SUBMIT_ADDITIONAL_PAYMENT_DETAILS_REQUEST_INVALID_JSON: 'submitAdditionalPaymentDetailsRequest does not contain valid JSON.',
-  AMOUNT_PLANNED_NOT_SAME: 'amountPlanned field must be the same as the amount in makePayment request',
+  AMOUNT_PLANNED_NOT_SAME: 'amountPlanned field must be the same as the amount in '
+    + 'makePayment request in the interface interactions or in the custom field',
   MAKE_PAYMENT_REQUEST_MISSING_REFERENCE: 'Required "reference" field is missing in makePaymentRequest.'
 }

--- a/extension/src/validator/error-messages.js
+++ b/extension/src/validator/error-messages.js
@@ -5,6 +5,6 @@ module.exports = {
   // eslint-disable-next-line max-len
   SUBMIT_ADDITIONAL_PAYMENT_DETAILS_REQUEST_INVALID_JSON: 'submitAdditionalPaymentDetailsRequest does not contain valid JSON.',
   AMOUNT_PLANNED_NOT_SAME: 'amountPlanned field must be the same as the amount in '
-    + 'makePayment request in the interface interactions or in the custom field',
+    + 'makePaymentRequest in the interface interactions or makePaymentRequest  in the custom field',
   MAKE_PAYMENT_REQUEST_MISSING_REFERENCE: 'Required "reference" field is missing in makePaymentRequest.'
 }

--- a/extension/src/validator/error-messages.js
+++ b/extension/src/validator/error-messages.js
@@ -4,6 +4,6 @@ module.exports = {
   MAKE_PAYMENT_REQUEST_INVALID_JSON: 'makePaymentRequest does not contain valid JSON.',
   // eslint-disable-next-line max-len
   SUBMIT_ADDITIONAL_PAYMENT_DETAILS_REQUEST_INVALID_JSON: 'submitAdditionalPaymentDetailsRequest does not contain valid JSON.',
-  AMOUNT_PLANNED_CHANGE_NOT_ALLOWED: 'amountPlanned field cannot be changed after makePayment request is made to Adyen',
+  AMOUNT_PLANNED_NOT_SAME: 'amountPlanned field must be the same as the amount in makePayment request',
   MAKE_PAYMENT_REQUEST_MISSING_REFERENCE: 'Required "reference" field is missing in makePaymentRequest.'
 }

--- a/extension/src/validator/validator-builder.js
+++ b/extension/src/validator/validator-builder.js
@@ -31,16 +31,19 @@ function withPayment (paymentObject) {
       return this
     },
     validateAmountPlanned () {
-      const makePaymentRequestString = paymentObject.custom.fields.makePaymentRequest
+      const makePaymentRequestString = paymentObject.custom
+        && paymentObject.custom.fields
+        && paymentObject.custom.fields.makePaymentRequest
 
       if (makePaymentRequestString) {
         const { amount } = JSON.parse(makePaymentRequestString)
-        const oldAmount = amount.value
-        const newAmount = paymentObject.amountPlanned.centAmount
-        const oldCurrencyCode = amount.currency
-        const newCurrencyCode = paymentObject.amountPlanned.currencyCode
-        if (oldAmount !== newAmount || oldCurrencyCode !== newCurrencyCode)
-          errors.amountPlanned = errorMessages.AMOUNT_PLANNED_CHANGE_NOT_ALLOWED
+        const amountInMakePaymentRequest = amount.value
+        const amountPlannedValue = paymentObject.amountPlanned.centAmount
+        const currencyInMakePaymentRequest = amount.currency
+        const currencyInAmountPlanned = paymentObject.amountPlanned.currencyCode
+        if (amountInMakePaymentRequest !== amountPlannedValue
+          || currencyInMakePaymentRequest !== currencyInAmountPlanned)
+          errors.amountPlanned = errorMessages.AMOUNT_PLANNED_NOT_SAME
       }
       return this
     },

--- a/extension/src/validator/validator-builder.js
+++ b/extension/src/validator/validator-builder.js
@@ -1,6 +1,7 @@
 const _ = require('lodash')
 const pU = require('../paymentHandler/payment-utils')
 const errorMessages = require('./error-messages')
+const c = require('../config/constants')
 
 function withPayment (paymentObject) {
   const errors = {}
@@ -31,12 +32,20 @@ function withPayment (paymentObject) {
       return this
     },
     validateAmountPlanned () {
-      const makePaymentRequestString = paymentObject.custom
-        && paymentObject.custom.fields
-        && paymentObject.custom.fields.makePaymentRequest
-
-      if (makePaymentRequestString) {
-        const { amount } = JSON.parse(makePaymentRequestString)
+      let amount
+      const makePaymentRequestInterfaceInteraction = pU.getLatestInterfaceInteraction(
+        paymentObject.interfaceInteractions, c.CTP_INTERACTION_TYPE_MAKE_PAYMENT
+      )
+      if (makePaymentRequestInterfaceInteraction)
+        amount = JSON.parse(makePaymentRequestInterfaceInteraction.fields.request).amount
+      else {
+        const makePaymentRequestString = paymentObject.custom
+          && paymentObject.custom.fields
+          && paymentObject.custom.fields.makePaymentRequest
+        if (makePaymentRequestString)
+          amount = JSON.parse(makePaymentRequestString)
+      }
+      if (amount) {
         const amountInMakePaymentRequest = amount.value
         const amountPlannedValue = paymentObject.amountPlanned.centAmount
         const currencyInMakePaymentRequest = amount.currency

--- a/extension/src/validator/validator-builder.js
+++ b/extension/src/validator/validator-builder.js
@@ -43,7 +43,7 @@ function withPayment (paymentObject) {
           && paymentObject.custom.fields
           && paymentObject.custom.fields.makePaymentRequest
         if (makePaymentRequestString)
-          amount = JSON.parse(makePaymentRequestString)
+          amount = JSON.parse(makePaymentRequestString).amount
       }
       if (amount) {
         const amountInMakePaymentRequest = amount.value

--- a/extension/src/validator/validator-builder.js
+++ b/extension/src/validator/validator-builder.js
@@ -1,7 +1,6 @@
 const _ = require('lodash')
 const pU = require('../paymentHandler/payment-utils')
 const errorMessages = require('./error-messages')
-const c = require('../config/constants')
 
 function withPayment (paymentObject) {
   const errors = {}
@@ -32,12 +31,10 @@ function withPayment (paymentObject) {
       return this
     },
     validateAmountPlanned () {
-      const oldMakePaymentRequestObj = pU.getLatestInterfaceInteraction(
-        paymentObject.interfaceInteractions, c.CTP_INTERACTION_TYPE_MAKE_PAYMENT
-      )
+      const makePaymentRequestString = paymentObject.custom.fields.makePaymentRequest
 
-      if (oldMakePaymentRequestObj) {
-        const { amount } = JSON.parse(oldMakePaymentRequestObj.fields.request)
+      if (makePaymentRequestString) {
+        const { amount } = JSON.parse(makePaymentRequestString)
         const oldAmount = amount.value
         const newAmount = paymentObject.amountPlanned.centAmount
         const oldCurrencyCode = amount.currency

--- a/extension/test/unit/payment-handler.spec.js
+++ b/extension/test/unit/payment-handler.spec.js
@@ -139,17 +139,13 @@ describe('payment-handler::execute', () => {
       'then it should return errors', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
       ctpPaymentClone.amountPlanned.centAmount = 0
-      ctpPaymentClone.interfaceInteractions = [{
-        fields: {
-          request: JSON.stringify({
+      ctpPaymentClone.custom.fields.makePaymentRequest = JSON.stringify({
+            reference: 'YOUR_ORDER_NUMBER',
             amount: {
               currency: 'EUR',
               value: 1000
             }
-          }),
-          type: 'makePayment'
-        }
-      }]
+          })
 
       const response = await handlePayment(ctpPaymentClone)
 
@@ -162,50 +158,12 @@ describe('payment-handler::execute', () => {
       'then it should ignore the update', async () => {
       const ctpPaymentClone = _.cloneDeep(ctpPayment)
       ctpPaymentClone.amountPlanned.centAmount = 0
-      ctpPaymentClone.interfaceInteractions = []
+      ctpPaymentClone.custom.fields = []
 
       const response = await handlePayment(ctpPaymentClone)
 
       expect(response.success).to.equal(true)
       expect(response.data.actions).to.deep.equal([])
-    })
-
-    it('when amountPlanned is updated and multiple makePayment exists, ' +
-      'then it should check with the newest request', async () => {
-      const ctpPaymentClone = _.cloneDeep(ctpPayment)
-      ctpPaymentClone.amountPlanned.centAmount = 0
-      ctpPaymentClone.interfaceInteractions = [
-        {
-          fields: {
-            request: JSON.stringify({
-              amount: {
-                currency: 'EUR',
-                value: 0
-              }
-            }),
-            createdAt: '2019-05-12T07:37:36.241Z',
-            type: 'makePayment'
-          }
-        },
-        {
-          fields: {
-            request: JSON.stringify({
-              amount: {
-                currency: 'EUR',
-                value: 1000
-              }
-            }),
-            createdAt: '2020-05-12T07:37:36.241Z',
-            type: 'makePayment'
-          }
-        }
-      ]
-
-      const response = await handlePayment(ctpPaymentClone)
-
-      expect(response.success).to.equal(false)
-      expect(response.data.errors).to.have.lengthOf.above(0)
-      expect(response.data.errors[0].message).to.equal(errorMessage.AMOUNT_PLANNED_CHANGE_NOT_ALLOWED)
     })
   })
 })

--- a/extension/test/unit/payment-handler.spec.js
+++ b/extension/test/unit/payment-handler.spec.js
@@ -151,7 +151,7 @@ describe('payment-handler::execute', () => {
 
       expect(response.success).to.equal(false)
       expect(response.data.errors).to.have.lengthOf.above(0)
-      expect(response.data.errors[0].message).to.equal(errorMessage.AMOUNT_PLANNED_CHANGE_NOT_ALLOWED)
+      expect(response.data.errors[0].message).to.equal(errorMessage.AMOUNT_PLANNED_NOT_SAME)
     })
 
     it('when amountPlanned is updated and makePayment request does not exist, ' +

--- a/extension/test/unit/validator-builder.spec.js
+++ b/extension/test/unit/validator-builder.spec.js
@@ -61,70 +61,69 @@ describe('Validator builder', () => {
   })
 
   it('payment has different amountPlanned and amount in makePaymentRequest interface interaction, ' +
-    'validateAmountPlanned() should return error object',
-    async () => {
-      const payment = {
-        amountPlanned: {
-          type: 'centPrecision',
-          currencyCode: 'EUR',
-          centAmount: 10,
-          fractionDigits: 2
-        },
-        custom: {
+    'validateAmountPlanned() should return error object', async () => {
+    const payment = {
+      amountPlanned: {
+        type: 'centPrecision',
+        currencyCode: 'EUR',
+        centAmount: 10,
+        fractionDigits: 2
+      },
+      custom: {
+        fields: {
+          makePaymentRequest: JSON.stringify({
+            amount: {
+              currency: 'EUR',
+              value: 10
+            }
+          })
+        }
+      },
+      interfaceInteractions: [
+        {
           fields: {
-            makePaymentRequest: JSON.stringify({
+            type: 'makePayment',
+            request: JSON.stringify({
               amount: {
                 currency: 'EUR',
                 value: 10
               }
-            })
+            }),
+            createdAt: '2018-05-14T07:18:37.560Z'
           }
         },
-        interfaceInteractions: [
-          {
-            fields: {
-              type: 'makePayment',
-              request: JSON.stringify({
-                amount: {
-                  currency: 'EUR',
-                  value: 10
-                }
-              }),
-              createdAt: '2018-05-14T07:18:37.560Z'
-            }
-          },
-          {
-            fields: {
-              type: 'makePayment',
-              request: JSON.stringify({
-                amount: {
-                  currency: 'EUR',
-                  value: 1000
-                }
-              }),
-              createdAt: '2020-05-14T07:18:37.560Z'
-            }
-          },
-          {
-            fields: {
-              type: 'makePayment',
-              request: JSON.stringify({
-                amount: {
-                  currency: 'EUR',
-                  value: 10
-                }
-              }),
-              createdAt: '2019-05-14T07:18:37.560Z'
-            }
+        {
+          fields: {
+            type: 'makePayment',
+            request: JSON.stringify({
+              amount: {
+                currency: 'EUR',
+                value: 1000
+              }
+            }),
+            createdAt: '2020-05-14T07:18:37.560Z'
           }
-        ]
-      }
+        },
+        {
+          fields: {
+            type: 'makePayment',
+            request: JSON.stringify({
+              amount: {
+                currency: 'EUR',
+                value: 10
+              }
+            }),
+            createdAt: '2019-05-14T07:18:37.560Z'
+          }
+        }
+      ]
+    }
 
-      const errorObject = ValidatorBuilder.withPayment(payment)
-        .validateAmountPlanned()
-        .getErrors()
-      expect(errorObject.amountPlanned).to.equal(AMOUNT_PLANNED_NOT_SAME)
-    })
+    const errorObject = ValidatorBuilder.withPayment(payment)
+      .validateAmountPlanned()
+      .getErrors()
+    expect(errorObject.amountPlanned).to.equal(AMOUNT_PLANNED_NOT_SAME)
+  })
 
   it('on missing reference in makePaymentRequest should return error object', async () => {
     const makePaymentRequestDraft = {

--- a/extension/test/unit/validator-builder.spec.js
+++ b/extension/test/unit/validator-builder.spec.js
@@ -6,7 +6,7 @@ const {
   GET_PAYMENT_METHODS_REQUEST_INVALID_JSON,
   MAKE_PAYMENT_REQUEST_INVALID_JSON,
   SUBMIT_ADDITIONAL_PAYMENT_DETAILS_REQUEST_INVALID_JSON,
-  AMOUNT_PLANNED_CHANGE_NOT_ALLOWED,
+  AMOUNT_PLANNED_NOT_SAME,
   MAKE_PAYMENT_REQUEST_MISSING_REFERENCE
 } = require('../../src/validator/error-messages')
 
@@ -55,7 +55,7 @@ describe('Validator builder', () => {
     const errorObject = ValidatorBuilder.withPayment(payment)
       .validateAmountPlanned()
       .getErrors()
-    expect(errorObject.amountPlanned).to.equal(AMOUNT_PLANNED_CHANGE_NOT_ALLOWED)
+    expect(errorObject.amountPlanned).to.equal(AMOUNT_PLANNED_NOT_SAME)
   })
 
   it('on missing reference in makePaymentRequest should return error object', async () => {

--- a/extension/test/unit/validator-builder.spec.js
+++ b/extension/test/unit/validator-builder.spec.js
@@ -32,7 +32,8 @@ describe('Validator builder', () => {
       .to.equal(SUBMIT_ADDITIONAL_PAYMENT_DETAILS_REQUEST_INVALID_JSON)
   })
 
-  it('when having a different amountPlanned and amount in makePaymentRequest, ' +
+  it('payment has different amountPlanned and amount in makePaymentRequest custom field ' +
+    'and interface interaction is empty, ' +
     'validateAmountPlanned() should return error object', async () => {
     const payment = {
       amountPlanned: {
@@ -50,13 +51,80 @@ describe('Validator builder', () => {
             }
           })
         }
-      }
+      },
+      interfaceInteractions: []
     }
     const errorObject = ValidatorBuilder.withPayment(payment)
       .validateAmountPlanned()
       .getErrors()
     expect(errorObject.amountPlanned).to.equal(AMOUNT_PLANNED_NOT_SAME)
   })
+
+  it('payment has different amountPlanned and amount in makePaymentRequest interface interaction, ' +
+    'validateAmountPlanned() should return error object',
+    async () => {
+      const payment = {
+        amountPlanned: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 10,
+          fractionDigits: 2
+        },
+        custom: {
+          fields: {
+            makePaymentRequest: JSON.stringify({
+              amount: {
+                currency: 'EUR',
+                value: 10
+              }
+            })
+          }
+        },
+        interfaceInteractions: [
+          {
+            fields: {
+              type: 'makePayment',
+              request: JSON.stringify({
+                amount: {
+                  currency: 'EUR',
+                  value: 10
+                }
+              }),
+              createdAt: '2018-05-14T07:18:37.560Z'
+            }
+          },
+          {
+            fields: {
+              type: 'makePayment',
+              request: JSON.stringify({
+                amount: {
+                  currency: 'EUR',
+                  value: 1000
+                }
+              }),
+              createdAt: '2020-05-14T07:18:37.560Z'
+            }
+          },
+          {
+            fields: {
+              type: 'makePayment',
+              request: JSON.stringify({
+                amount: {
+                  currency: 'EUR',
+                  value: 10
+                }
+              }),
+              createdAt: '2019-05-14T07:18:37.560Z'
+            }
+          }
+        ]
+      }
+
+      const errorObject = ValidatorBuilder.withPayment(payment)
+        .validateAmountPlanned()
+        .getErrors()
+      expect(errorObject.amountPlanned).to.equal(AMOUNT_PLANNED_NOT_SAME)
+    })
 
   it('on missing reference in makePaymentRequest should return error object', async () => {
     const makePaymentRequestDraft = {

--- a/extension/test/unit/validator-builder.spec.js
+++ b/extension/test/unit/validator-builder.spec.js
@@ -32,7 +32,7 @@ describe('Validator builder', () => {
       .to.equal(SUBMIT_ADDITIONAL_PAYMENT_DETAILS_REQUEST_INVALID_JSON)
   })
 
-  it('on changing amountPlanned when different amountPlanned exists in the interaction, ' +
+  it('when having a different amountPlanned and amount in makePaymentRequest, ' +
     'validateAmountPlanned() should return error object', async () => {
     const payment = {
       amountPlanned: {
@@ -42,46 +42,15 @@ describe('Validator builder', () => {
         fractionDigits: 2
       },
       custom: {
-        fields: {}
-      },
-      interfaceInteractions: [
-        {
-          fields: {
-            type: 'makePayment',
-            request: JSON.stringify({
-              amount: {
-                currency: 'EUR',
-                value: 10
-              }
-            }),
-            createdAt: '2018-05-14T07:18:37.560Z'
-          }
-        },
-        {
-          fields: {
-            type: 'makePayment',
-            request: JSON.stringify({
-              amount: {
-                currency: 'EUR',
-                value: 1000
-              }
-            }),
-            createdAt: '2020-05-14T07:18:37.560Z'
-          }
-        },
-        {
-          fields: {
-            type: 'makePayment',
-            request: JSON.stringify({
-              amount: {
-                currency: 'EUR',
-                value: 10
-              }
-            }),
-            createdAt: '2019-05-14T07:18:37.560Z'
-          }
+        fields: {
+          makePaymentRequest: JSON.stringify({
+            amount: {
+              currency: 'EUR',
+              value: 1000
+            }
+          })
         }
-      ]
+      }
     }
     const errorObject = ValidatorBuilder.withPayment(payment)
       .validateAmountPlanned()


### PR DESCRIPTION
The problem: it is possible to create a payment with different values in `amountPlanned` and `makePaymentRequest custom field`. The problem is we're checking interface interaction for `makePaymentRequest`. If there's no interface interaction yet, we allow the value to be not matching. This leads to inconsistent payments that always fails.

Solution: `makePaymentRequest custom field` should be checked with `amountPlanned` if there's no interface interactions.

Fixes: https://github.com/commercetools/commercetools-adyen-integration/issues/461