### PR TITLE
#399 take Authorized transaction into consideration when doing refund

### DIFF
--- a/extension/docs/Refund.md
+++ b/extension/docs/Refund.md
@@ -6,7 +6,9 @@ If you want to return the funds to your shopper, for example if they returned an
 ### Make an API call to refund a payment
 
 #### Prerequisites
-It is required that the payment has one `Charge` transaction with state `Success`. From this transaction, the `interactionId` field is being used as `originalReference` for the Adyen refund request.
+It is required that the payment has one `Charge` transaction with state `Success`.
+If `Charge` transaction with state `Success` is NOT present, then it is required that the payment has one `Authorized` transaction with state `Success`.
+From either `Charge` or `Authorized` transaction, the `interactionId` field is being used as `originalReference` for the Adyen refund request.
 
 #### Steps
 To make a (partial) refund, [add **at least one** transaction](https://docs.commercetools.com/http-api-projects-payments#add-transaction) with type `Refund` and state `Initial` to the commercetools payment.
@@ -107,6 +109,9 @@ By adding too many transactions at once, extension module will need more time to
 1. Adyen processes the refunds asynchronously. Therefore the response from Adyen for extension module will always be `refund-received`.
 However, the final response comes later for the notification module and it can also contain failure.
 1. [Unreferenced refund](https://docs.adyen.com/checkout/refund#unreferenced-refund) is not supported.
+1. After the payment is authorized, it could take some time until the payment is captured. In Adyen, the payment has state `SentForSettle`. 
+During this time, there is no `Charge` transaction with state `Success`. However, it is still possible to do (partial) refunds.
+Therefore `Authorized` transactions are also taken into consideration when getting the `interactionId` field (see [Prerequisites](#Prerequisites))
 
 ### Further resources
 1. [Adyen refund documentation](https://docs.adyen.com/checkout/refund)

--- a/extension/src/paymentHandler/payment-handler.js
+++ b/extension/src/paymentHandler/payment-handler.js
@@ -45,7 +45,8 @@ async function handlePayment (paymentObject) {
 
 function _isRefund (paymentObject) {
   return pU.listRefundTransactionsInit(paymentObject).length > 0
-    && pU.getChargeTransactionSuccess(paymentObject)
+    && (pU.getChargeTransactionSuccess(paymentObject)
+      || pU.getAuthorizationTransactionSuccess(paymentObject))
 }
 
 function _getPaymentHandlers (paymentObject) {

--- a/extension/src/paymentHandler/refund-payment.handler.js
+++ b/extension/src/paymentHandler/refund-payment.handler.js
@@ -7,7 +7,10 @@ const {
 
 async function execute (paymentObject) {
   const refundInitTransactions = pU.listRefundTransactionsInit(paymentObject)
-  const chargeSuccessTransaction = pU.getChargeTransactionSuccess(paymentObject)
+  let transaction = pU.getChargeTransactionSuccess(paymentObject)
+  if (!transaction)
+    transaction = pU.getAuthorizationTransactionSuccess(paymentObject)
+  const interactionId = transaction.interactionId
 
   const actions = []
 
@@ -17,7 +20,7 @@ async function execute (paymentObject) {
         value: refundTransaction.amount.centAmount,
         currency: refundTransaction.amount.currencyCode
       },
-      originalReference: chargeSuccessTransaction.interactionId,
+      originalReference: interactionId,
       reference: paymentObject.key
     }
 

--- a/extension/test/integration/refund-payment.handler.spec.js
+++ b/extension/test/integration/refund-payment.handler.spec.js
@@ -9,12 +9,22 @@ const { createAddTransactionAction } = require('../../src/paymentHandler/payment
 
 describe('::refund::', () => {
   let ctpClient
-  let payment
 
   beforeEach(async () => {
     ctpClient = ctpClientBuilder.get()
     await iTSetUp.cleanupCtpResources(ctpClient)
     await iTSetUp.initServerAndExtension({ ctpClient })
+  })
+
+  afterEach(async () => {
+    await iTSetUp.stopRunningServers()
+    await iTSetUp.cleanupCtpResources(ctpClient)
+  })
+
+  it('given a payment with "charge success transaction" ' +
+    'when multiple "refund initial transactions" are added ' +
+    'then Adyen should response with [refund-received] for each transaction ' +
+    'and payment should have "refund pending transactions"', async () => {
     const paymentDraft = {
       amountPlanned: {
         currencyCode: 'EUR',
@@ -43,19 +53,87 @@ describe('::refund::', () => {
       ]
     }
 
-    const result = await ctpClient.create(ctpClient.builder.payments, paymentDraft)
-    payment = result.body
+    const { body: payment } = await ctpClient.create(ctpClient.builder.payments, paymentDraft)
+
+    const { statusCode, body: refundPayment } = await ctpClient.update(ctpClient.builder.payments,
+      payment.id, payment.version,
+      [
+        createAddTransactionAction({
+          type: 'Refund',
+          state: 'Initial',
+          currency: 'EUR',
+          amount: 500
+        }),
+        createAddTransactionAction({
+          type: 'Refund',
+          state: 'Initial',
+          currency: 'EUR',
+          amount: 300
+        }),
+        createAddTransactionAction({
+          type: 'Refund',
+          state: 'Initial',
+          currency: 'EUR',
+          amount: 100
+        })
+      ])
+
+    expect(statusCode).to.be.equal(200)
+
+    expect(refundPayment.transactions).to.have.lengthOf(4)
+    const refundTransactions = [refundPayment.transactions[1],
+      refundPayment.transactions[2], refundPayment.transactions[3]]
+    for (const refundTransaction of refundTransactions) {
+      expect(refundTransaction.type).to.equal('Refund')
+      expect(refundTransaction.state).to.equal('Pending')
+    }
+
+    const interfaceInteractions = refundPayment.interfaceInteractions
+      .filter(interaction => interaction.fields.type === CTP_INTERACTION_TYPE_REFUND)
+
+    for (const interfaceInteraction of interfaceInteractions) {
+      const adyenResponse = JSON.parse(interfaceInteraction.fields.response)
+      expect(adyenResponse.response).to.equal('[refund-received]')
+      const refundTransaction = refundTransactions
+        .find(transaction => transaction.interactionId === adyenResponse.pspReference)
+      expect(refundTransaction).to.exist
+    }
   })
 
-  afterEach(async () => {
-    await iTSetUp.stopRunningServers()
-    await iTSetUp.cleanupCtpResources(ctpClient)
-  })
-
-  it('given a payment with "charge success transaction" ' +
+  it('given a payment with "authorization success transaction" ' +
     'when multiple "refund initial transactions" are added ' +
     'then Adyen should response with [refund-received] for each transaction ' +
     'and payment should have "refund pending transactions"', async () => {
+    const paymentDraft = {
+      amountPlanned: {
+        currencyCode: 'EUR',
+        centAmount: 1000,
+      },
+      paymentMethodInfo: {
+        paymentInterface: CTP_ADYEN_INTEGRATION
+      },
+      custom: {
+        type: {
+          typeId: 'type',
+          key: CTP_PAYMENT_CUSTOM_TYPE_KEY
+        },
+        fields: {}
+      },
+      transactions: [
+        {
+          type: 'Authorization',
+          amount: {
+            currencyCode: 'EUR',
+            centAmount: 1000,
+          },
+          interactionId: '883592826488441K',
+          state: 'Success'
+        }
+      ]
+    }
+
+    const { body: payment } = await ctpClient.create(ctpClient.builder.payments, paymentDraft)
+
     const { statusCode, body: refundPayment } = await ctpClient.update(ctpClient.builder.payments,
       payment.id, payment.version,
       [


### PR DESCRIPTION
After the payment is authorized, it could take some time until the payment is captured. In Adyen, the Adyen payment has state `SentForSettle`.
During this time, there is no `Charge` transaction with state `Success` in the CTP payment. However, it is still possible to do (partial) refunds.
Therefore `Authorized` transaction in the CTP payment should also be taken into consideration when getting the `interactionId` field