### PR TITLE
Update credit card date in e2e tests

### DIFF
--- a/extension/test/e2e/credit-card-3ds-redirect.spec.js
+++ b/extension/test/e2e/credit-card-3ds-redirect.spec.js
@@ -73,7 +73,7 @@ describe('::creditCardPayment3dsRedirect::', () => {
     ({
       name,
       creditCardNumber,
-      creditCardDate = '10/20',
+      creditCardDate = '03/30',
       creditCardCvc = '737',
     }) => {
       // eslint-disable-next-line no-template-curly-in-string


### PR DESCRIPTION
As tests suddenly fail, I had a quick look and saw that credit card valid dates were already in the past. So I updated them.