### PR TITLE
Change module names in package.json

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "commercetools-adyen-integration",
+  "name": "commercetools-adyen-integration-extension",
   "version": "7.0.0",
   "description": "Integration between Commercetools and Adyen payment service provider",
   "license": "MIT",

--- a/notification/package.json
+++ b/notification/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "commercetools-adyen-integration",
+  "name": "commercetools-adyen-integration-notification",
   "version": "7.0.0",
   "description": "Part of the integration of Adyen with commercetools responsible to receive and process notifications from Adyen",
   "scripts": {


### PR DESCRIPTION
Changed the names of the extension and notification modules to be unique for each in package.json files, as they are different packages.