### PR TITLE
use unique names on the package.json

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "commercetools-adyen-integration",
-  "version": "7.0.0",
+  "name": "commercetools-adyen-integration-extension",
+  "version": "7.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "commercetools-adyen-integration",
-  "version": "7.0.0",
-  "description": "Integration between Commercetools and Adyen payment service provider",
+  "name": "commercetools-adyen-integration-extension",
+  "version": "7.0.1",
+  "description": "Integration between commercetools and Adyen payment service provider",
   "license": "MIT",
   "scripts": {
     "check-coverage": "nyc check-coverage --statements 97",

--- a/extension/src/ctp.js
+++ b/extension/src/ctp.js
@@ -61,7 +61,7 @@ function createCtpClient({
 
   const userAgentMiddleware = createUserAgentMiddleware({
     libraryName: packageJson.name,
-    libraryVersion: `${packageJson.version}/extension`,
+    libraryVersion: `${packageJson.version}`,
     contactUrl: packageJson.homepage,
     contactEmail: packageJson.author.email,
   })

--- a/notification/package-lock.json
+++ b/notification/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "commercetools-adyen-integration",
-  "version": "7.0.0",
+  "name": "commercetools-adyen-integration-notification",
+  "version": "7.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/notification/package.json
+++ b/notification/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "commercetools-adyen-integration",
-  "version": "7.0.0",
+  "name": "commercetools-adyen-integration-notification",
+  "version": "7.0.1",
   "description": "Part of the integration of Adyen with commercetools responsible to receive and process notifications from Adyen",
   "scripts": {
     "check-coverage": "nyc check-coverage --statements 93",

--- a/notification/src/utils/ctp.js
+++ b/notification/src/utils/ctp.js
@@ -43,7 +43,7 @@ function createCtpClient({
 
   const userAgentMiddleware = createUserAgentMiddleware({
     libraryName: packageJson.name,
-    libraryVersion: `${packageJson.version}/notification`,
+    libraryVersion: `${packageJson.version}`,
     contactUrl: packageJson.homepage,
     contactEmail: packageJson.author.email,
   })


### PR DESCRIPTION
Addresses: #572 

-----------
Let's discuss this PR based on the user agent changes, normally package name is better to be unique.

### Changes 

Adyen `applicationInfo` will be 

```` JSON
{
  "merchantApplication": {
    "name": "commercetools-adyen-integration-extension",
    "version": "7.0.1"
  },
  "externalPlatform": {
    "name": "commercetools",
    "integrator": "commercetools Professional Services"
  }
}
````
CTP user agent will be:

````
http_useragent:commercetools-js-sdk Node.js/14.15.5 (linux; x64) 
commercetools-adyen-integration-notification/7.0.1 (+https://github.com/commercetools/commercetools-adyen-
integration; +ps-dev@commercetools.com)
````

