### PR TITLE
Shorten metadata.commercetoolsProjectKey name

### DIFF
--- a/extension/.prettierignore
+++ b/extension/.prettierignore
@@ -5,4 +5,4 @@ package.json
 package-lock.json
 .prettierignore
 .eslintrc
-
+.nyc_output

--- a/extension/docs/WebComponentsIntegrationGuide.md
+++ b/extension/docs/WebComponentsIntegrationGuide.md
@@ -779,9 +779,9 @@ This will either:
 `commercetools-adyen-integration` supports multi-tenancy to serve multiple Adyen merchant accounts/commercetools projects
 with one application instance. This architectural style leverages sharing and scalability to provide cost-efficient hosting.
 
-In order for `commercetools-adyen-integration` to know which project and merchant account it should communicate with, so `adyenMerchantAccount` and `commercetoolsProjectKey` custom fields must be provided on payment creation.
+In order for `commercetools-adyen-integration` to know which project and merchant account it should communicate with, `adyenMerchantAccount` and `commercetoolsProjectKey` custom fields must be provided on payment creation.
 
-> `commercetoolsProjectKey` is passed to Adyen using the field [`metadata.commercetoolsProjectKey`](https://docs.adyen.com/api-explorer/#/CheckoutService/v66/post/payments__reqParam_metadata). This field is also present in every notification from Adyen to help with matching the correct commercetools project.
+> `commercetoolsProjectKey` is passed to Adyen using the field [`metadata.ctProjectKey`](https://docs.adyen.com/api-explorer/#/CheckoutService/v66/post/payments__reqParam_metadata). This field is also present in every notification from Adyen to help with matching the correct commercetools project.
 
 # Bad Practices
 

--- a/extension/docs/WebComponentsIntegrationGuide.md
+++ b/extension/docs/WebComponentsIntegrationGuide.md
@@ -783,7 +783,7 @@ In order for `commercetools-adyen-integration` to know which project and merchan
 
 > `commercetoolsProjectKey` is passed to Adyen using the field [`metadata.ctProjectKey`](https://docs.adyen.com/api-explorer/#/CheckoutService/v66/post/payments__reqParam_metadata). This field is also present in every notification from Adyen to help with matching the correct commercetools project.
 
-**IMPORTANT: `commercetoolsProjectKey` must not have more than 80 characters. This is due to length restrictions from the Adyen API.** 
+**IMPORTANT: `commercetoolsProjectKey` must not have more than 80 characters. This is due to length restrictions of the Adyen API.** 
 
 # Bad Practices
 

--- a/extension/docs/WebComponentsIntegrationGuide.md
+++ b/extension/docs/WebComponentsIntegrationGuide.md
@@ -783,7 +783,7 @@ In order for `commercetools-adyen-integration` to know which project and merchan
 
 > `commercetoolsProjectKey` is passed to Adyen using the field [`metadata.ctProjectKey`](https://docs.adyen.com/api-explorer/#/CheckoutService/v66/post/payments__reqParam_metadata). This field is also present in every notification from Adyen to help with matching the correct commercetools project.
 
-**IMPORTANT: `commercetoolsProjectKey` must not have more than 80 characters. This is due to length restrictions of the Adyen API.** 
+**IMPORTANT: `commercetoolsProjectKey` must not have more than 80 characters. This is due to length restrictions of the Adyen API.**
 
 # Bad Practices
 

--- a/extension/docs/WebComponentsIntegrationGuide.md
+++ b/extension/docs/WebComponentsIntegrationGuide.md
@@ -783,6 +783,8 @@ In order for `commercetools-adyen-integration` to know which project and merchan
 
 > `commercetoolsProjectKey` is passed to Adyen using the field [`metadata.ctProjectKey`](https://docs.adyen.com/api-explorer/#/CheckoutService/v66/post/payments__reqParam_metadata). This field is also present in every notification from Adyen to help with matching the correct commercetools project.
 
+**IMPORTANT: `commercetoolsProjectKey` must not have more than 80 characters. This is due to length restrictions from the Adyen API.** 
+
 # Bad Practices
 
 - **Never delete or un-assign** created payment objects during checkout from the cart. If required — clean up unused/obsolete payment objects by another asynchronous process instead.

--- a/extension/src/service/web-component-service.js
+++ b/extension/src/service/web-component-service.js
@@ -104,6 +104,8 @@ function extendRequestObjWithApplicationInfo(requestObj) {
 
 function extendRequestObjWithMetadata(requestObj, commercetoolsProjectKey) {
   requestObj.metadata = {
+    // metadata key must have length of max. 20 chars
+    // metadata value must have length of max. 80 chars
     ctProjectKey: commercetoolsProjectKey,
   }
 }

--- a/extension/src/service/web-component-service.js
+++ b/extension/src/service/web-component-service.js
@@ -104,7 +104,7 @@ function extendRequestObjWithApplicationInfo(requestObj) {
 
 function extendRequestObjWithMetadata(requestObj, commercetoolsProjectKey) {
   requestObj.metadata = {
-    commercetoolsProjectKey,
+    ctProjectKey: commercetoolsProjectKey,
   }
 }
 

--- a/extension/test/integration/klarna-make-payment.spec.js
+++ b/extension/test/integration/klarna-make-payment.spec.js
@@ -113,7 +113,7 @@ describe('::klarnaMakePayment with multiple projects use case::', () => {
     const makePaymentResponse = JSON.parse(makePaymentInteraction.response)
 
     expect(makePaymentRequest.metadata).to.deep.equal({
-      commercetoolsProjectKey,
+      ctProjectKey: commercetoolsProjectKey,
     })
     expect(makePaymentRequest.merchantAccount).to.be.equal(adyenMerchantAccount)
 

--- a/extension/test/integration/make-payment.handler.spec.js
+++ b/extension/test/integration/make-payment.handler.spec.js
@@ -101,7 +101,7 @@ describe('::make-payment with multiple adyen accounts use case::', () => {
     )
     const makePaymentRequest = JSON.parse(interfaceInteraction.fields.request)
     expect(makePaymentRequest.metadata).to.deep.equal({
-      commercetoolsProjectKey,
+      ctProjectKey: commercetoolsProjectKey,
     })
     expect(makePaymentRequest.merchantAccount).to.be.equal(adyenMerchantAccount)
 

--- a/notification/.prettierignore
+++ b/notification/.prettierignore
@@ -5,4 +5,4 @@ package.json
 package-lock.json
 .prettierignore
 .eslintrc
-
+.nyc_output

--- a/notification/docs/IntegrationGuide.md
+++ b/notification/docs/IntegrationGuide.md
@@ -46,7 +46,7 @@ Adyen sends notifications which look like this:
       "NotificationRequestItem": {
         "additionalData": {
           "hmacSignature": "cjiTz03EI0jkkysGDdPJQdLbecRVVU/5jm12/DTFEHo=",
-          "metadata.commercetoolsProjectKey": "YOUR_COMMERCETOOLS_PROJECT_KEY" // should match a project key in ADYEN_INTEGRATION_CONFIG
+          "metadata.ctProjectKey": "YOUR_COMMERCETOOLS_PROJECT_KEY" // should match a project key in ADYEN_INTEGRATION_CONFIG
         },
         "amount": {
           "currency": "EUR",

--- a/notification/src/utils/parser.js
+++ b/notification/src/utils/parser.js
@@ -24,7 +24,7 @@ function getCtpProjectConfig(notification) {
   if (!commercetoolsProjectKey) {
     throw new ValidationError({
       message:
-        'Notification can not be processed as "commercetoolsProjectKey"  was not found on the notification.',
+        'Notification can not be processed as "metadata.ctProjectKey"  was not found on the notification.',
     })
   }
 

--- a/notification/src/utils/parser.js
+++ b/notification/src/utils/parser.js
@@ -19,7 +19,7 @@ class ValidationError extends Error {
 function getCtpProjectConfig(notification) {
   const commercetoolsProjectKey =
     notification?.NotificationRequestItem?.additionalData?.[
-      `metadata.commercetoolsProjectKey`
+      `metadata.ctProjectKey`
     ]
   if (!commercetoolsProjectKey) {
     throw new ValidationError({

--- a/notification/test/integration/multitenancy.spec.js
+++ b/notification/test/integration/multitenancy.spec.js
@@ -48,12 +48,12 @@ describe('::multitenancy::', () => {
     const modifiedNotification2 = cloneDeep(notifications)
 
     modifiedNotification1.notificationItems[0].NotificationRequestItem.additionalData = {
-      'metadata.commercetoolsProjectKey': commercetoolsProjectKey1,
+      'metadata.ctProjectKey': commercetoolsProjectKey1,
     }
     modifiedNotification1.notificationItems[0].NotificationRequestItem.merchantAccountCode = adyenMerchantAccount1
 
     modifiedNotification2.notificationItems[0].NotificationRequestItem.additionalData = {
-      'metadata.commercetoolsProjectKey': commercetoolsProjectKey2,
+      'metadata.ctProjectKey': commercetoolsProjectKey2,
     }
     modifiedNotification2.notificationItems[0].NotificationRequestItem.merchantAccountCode = adyenMerchantAccount2
 

--- a/notification/test/integration/notification.handler.spec.js
+++ b/notification/test/integration/notification.handler.spec.js
@@ -21,10 +21,10 @@ describe('notification module', () => {
   const adyenMerchantAccount = config.getAllAdyenMerchantAccounts()[0]
   const adyenConfig = config.getAdyenConfig(adyenMerchantAccount)
   notifications.notificationItems[0].NotificationRequestItem.additionalData[
-    'metadata.commercetoolsProjectKey'
+    'metadata.ctProjectKey'
   ] = commercetoolsProjectKey
   notificationRefundFail.notificationItems[0].NotificationRequestItem.additionalData[
-    'metadata.commercetoolsProjectKey'
+    'metadata.ctProjectKey'
   ] = commercetoolsProjectKey
 
   before(async () => {
@@ -287,7 +287,7 @@ describe('notification module', () => {
         'REFUND'
       modifiedNotification.notificationItems[0].NotificationRequestItem.additionalData = {
         'modification.action': 'refund',
-        'metadata.commercetoolsProjectKey': commercetoolsProjectKey,
+        'metadata.ctProjectKey': commercetoolsProjectKey,
       }
       modifiedNotification.notificationItems[0].NotificationRequestItem.pspReference = refundInteractionId
 
@@ -384,7 +384,7 @@ describe('notification module', () => {
         'REFUND'
       successNotification1.notificationItems[0].NotificationRequestItem.additionalData = {
         'modification.action': 'refund',
-        'metadata.commercetoolsProjectKey': commercetoolsProjectKey,
+        'metadata.ctProjectKey': commercetoolsProjectKey,
       }
       successNotification1.notificationItems[0].NotificationRequestItem.pspReference = refundInteractionId1
 
@@ -487,7 +487,7 @@ describe('notification module', () => {
         'CANCEL_OR_REFUND'
       modifiedNotification.notificationItems[0].NotificationRequestItem.additionalData = {
         'modification.action': 'cancel',
-        'metadata.commercetoolsProjectKey': commercetoolsProjectKey,
+        'metadata.ctProjectKey': commercetoolsProjectKey,
       }
       modifiedNotification.notificationItems[0].NotificationRequestItem.pspReference = cancellationInteractionId
 

--- a/notification/test/resources/notification-refund-fail.json
+++ b/notification/test/resources/notification-refund-fail.json
@@ -17,7 +17,7 @@
         "reason": "Insufficient balance on payment",
         "success": "false",
         "additionalData": {
-          "metadata.commercetoolsProjectKey": "adyen-integration-test"
+          "metadata.ctProjectKey": "adyen-integration-test"
         }
       }
     }

--- a/notification/test/resources/notification.json
+++ b/notification/test/resources/notification.json
@@ -5,7 +5,7 @@
       "NotificationRequestItem": {
         "additionalData": {
           "hmacSignature": "cjiTz03EI0jkkysGDdPJQdLbecRVVU/5jm12/DTFEHo=",
-          "metadata.commercetoolsProjectKey": "adyen-integration-test"
+          "metadata.ctProjectKey": "adyen-integration-test"
         },
         "amount": {
           "currency": "EUR",

--- a/notification/test/unit/lambda.spec.js
+++ b/notification/test/unit/lambda.spec.js
@@ -19,7 +19,7 @@ describe('Lambda handler', () => {
       {
         NotificationRequestItem: {
           additionalData: {
-            'metadata.commercetoolsProjectKey': 'adyen-integration-test',
+            'metadata.ctProjectKey': 'adyen-integration-test',
           },
           merchantAccountCode: 'CommercetoolsGmbHDE775',
         },

--- a/notification/test/unit/notification.controller.spec.js
+++ b/notification/test/unit/notification.controller.spec.js
@@ -52,7 +52,7 @@ describe('notification controller', () => {
   })
 
   it(
-    'when request does not contain commercetoolsProjectKey, ' +
+    'when request does not contain ctProjectKey, ' +
       'it should log error and return "accepted" status',
     async () => {
       // prepare:

--- a/notification/test/unit/notification.controller.spec.js
+++ b/notification/test/unit/notification.controller.spec.js
@@ -82,7 +82,7 @@ describe('notification controller', () => {
         JSON.stringify({ notificationResponse: '[accepted]' })
       )
       expect(logSpy.firstCall.args[0].err.message).to.equal(
-        'Notification can not be processed as "commercetoolsProjectKey"  was not found on the notification.'
+        'Notification can not be processed as "metadata.ctProjectKey"  was not found on the notification.'
       )
     }
   )
@@ -145,7 +145,7 @@ describe('notification controller', () => {
     const responseEndSpy = sandbox.spy(responseMock, 'end')
     const notificationJson = _.cloneDeep(mockNotificationJson)
     notificationJson.notificationItems[0].NotificationRequestItem.additionalData = {
-      'metadata.commercetoolsProjectKey': 'nonExistingCtpProjectKey',
+      'metadata.ctProjectKey': 'nonExistingCtpProjectKey',
     }
     httpUtils.collectRequestData = () => JSON.stringify(notificationJson)
     module.exports = httpUtils

--- a/notification/test/unit/notification.controller.spec.js
+++ b/notification/test/unit/notification.controller.spec.js
@@ -101,7 +101,7 @@ describe('notification controller', () => {
 
     const notificationJson = _.cloneDeep(mockNotificationJson)
     notificationJson.notificationItems[0].NotificationRequestItem.additionalData = {
-      'metadata.commercetoolsProjectKey': 'testKey',
+      'metadata.ctProjectKey': 'testKey',
     }
     notificationJson.notificationItems[0].NotificationRequestItem.merchantAccountCode =
       'nonExistingMerchantAccount'

--- a/notification/test/unit/notification.handler.spec.js
+++ b/notification/test/unit/notification.handler.spec.js
@@ -51,7 +51,7 @@ describe('notification module', () => {
             value: 10100,
           },
           additionalData: {
-            'metadata.commercetoolsProjectKey': 'adyen-integration-test',
+            'metadata.ctProjectKey': 'adyen-integration-test',
           },
           eventCode: 'AUTHORISATION',
           eventDate: '2019-01-30T18:16:22+01:00',
@@ -135,7 +135,7 @@ describe('notification module', () => {
             value: 10100,
           },
           additionalData: {
-            'metadata.commercetoolsProjectKey': 'adyen-integration-test',
+            'metadata.ctProjectKey': 'adyen-integration-test',
           },
           eventCode: 'AUTHORISATION',
           eventDate: '2019-01-30T18:16:22+01:00',
@@ -214,7 +214,7 @@ describe('notification module', () => {
             value: 10100,
           },
           additionalData: {
-            'metadata.commercetoolsProjectKey': 'adyen-integration-test',
+            'metadata.ctProjectKey': 'adyen-integration-test',
           },
           eventCode: 'AUTHORISATION',
           eventDate: '2019-01-30T18:16:22+01:00',
@@ -282,7 +282,7 @@ describe('notification module', () => {
             value: 10100,
           },
           additionalData: {
-            'metadata.commercetoolsProjectKey': 'adyen-integration-test',
+            'metadata.ctProjectKey': 'adyen-integration-test',
           },
           eventCode: 'CANCELLATION',
           eventDate: '2019-01-30T18:16:22+01:00',
@@ -372,7 +372,7 @@ describe('notification module', () => {
             value: 10100,
           },
           additionalData: {
-            'metadata.commercetoolsProjectKey': 'adyen-integration-test',
+            'metadata.ctProjectKey': 'adyen-integration-test',
           },
           eventCode: 'CAPTURE',
           eventDate: '2019-01-30T18:16:22+01:00',
@@ -462,7 +462,7 @@ describe('notification module', () => {
             value: 10100,
           },
           additionalData: {
-            'metadata.commercetoolsProjectKey': 'adyen-integration-test',
+            'metadata.ctProjectKey': 'adyen-integration-test',
           },
           eventCode: 'CAPTURE_FAILED',
           eventDate: '2019-01-30T18:16:22+01:00',


### PR DESCRIPTION
Due to restrictions in the Adyen API, it's not allowed to have metadata key with length more than 20 characters and metadata values with more than 80 characters. In this PR, we fixed this problem.