### PR TITLE
Fix e2e test

### DIFF
--- a/extension/test/e2e/credit-card-3ds-native.spec.js
+++ b/extension/test/e2e/credit-card-3ds-native.spec.js
@@ -161,7 +161,7 @@ describe('::creditCardPayment3dsNative::', () => {
       makePaymentResponse
     )
 
-    await browserTab.waitForTimeout(3000)
+    await browserTab.waitForTimeout(10_000)
 
     // Submit additional details
     const creditCardNativePage = new CreditCardNativePage(browserTab, baseUrl)

--- a/extension/test/e2e/credit-card-3ds-native.spec.js
+++ b/extension/test/e2e/credit-card-3ds-native.spec.js
@@ -161,7 +161,7 @@ describe('::creditCardPayment3dsNative::', () => {
       makePaymentResponse
     )
 
-    await browserTab.waitForTimeout(2000)
+    await browserTab.waitForTimeout(3000)
 
     // Submit additional details
     const creditCardNativePage = new CreditCardNativePage(browserTab, baseUrl)


### PR DESCRIPTION
**Description**
The end-to-end test cases are flaky. It may randomly fail and block the build.

**Hints**
Extend the web browser timeout for waiting for the response. 
