### PR TITLE
cancelPayment does not transmit project name

### DIFF
--- a/extension/src/service/web-component-service.js
+++ b/extension/src/service/web-component-service.js
@@ -68,7 +68,7 @@ function cancelPayment(
   cancelPaymentRequestObj
 ) {
   const adyenCredentials = config.getAdyenConfig(merchantAccount)
-  extendRequestObjWithMetadata(cancelPaymentRequestObj)
+  extendRequestObjWithMetadata(cancelPaymentRequestObj, commercetoolsProjectKey)
   return callAdyen(
     `${adyenCredentials.legacyApiBaseUrl}/cancel`,
     merchantAccount,


### PR DESCRIPTION
the notifcation module can't update cancelled payments as the notification payload is missing the project name.
this fix adds it to the request payload in the extension module