### PR TITLE
Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,11 +5,5 @@
   "automerge": true,
   "schedule": ["every weekend"],
   "ignoreDeps": ["nock"],
-  "prConcurrentLimit": 10,
-  "packageRules": [
-    {
-      "matchDatasources": ["npm"],
-      "stabilityDays": 3
-    }
-  ]
+  "prConcurrentLimit": 10
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
   ],
   "automerge": true,
   "schedule": ["every weekend"],
-  "ignoreDeps": ["nock"],
   "groupName": "all",
   "docker": {
     "enabled":  false

--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,8 @@
   "automerge": true,
   "schedule": ["every weekend"],
   "ignoreDeps": ["nock"],
-  "prConcurrentLimit": 10
+  "prConcurrentLimit": 10,
+  "docker": {
+    "enabled":  false
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -5,8 +5,9 @@
   "automerge": true,
   "schedule": ["every weekend"],
   "ignoreDeps": ["nock"],
-  "prConcurrentLimit": 10,
+  "groupName": "all",
   "docker": {
     "enabled":  false
-  }
+  },
+  "prConcurrentLimit": 10
 }


### PR DESCRIPTION
* Disable updates in the docker file. (Ex: avoid updating node versions)
* Batch them all into 1 PR weekly.
* StabilityDays:
     Renovate creates PR immediately once it comes across a new version and then this PR doesn't merge until next 3 days to 
     check the stability.
     It is a noise in the Github repository with a lot of PR's.

**Note**: We still have a drawback using Batching, Because if any single update fails, The PR will not merge and we have to manually check the PR. - Still I prefer this way, instead of having a lot of PR's.
May be check this issue for more details:  https://github.com/renovatebot/renovate/issues/1342
