### PR TITLE
Fix for validator-builder.js

### DIFF
--- a/extension/src/validator/validator-builder.js
+++ b/extension/src/validator/validator-builder.js
@@ -81,7 +81,7 @@ function withPayment(paymentObject) {
           amount = JSON.parse(makePaymentRequestString).amount
       }
       if (amount) {
-        const amountInMakePaymentRequest = amount.value
+        const amountInMakePaymentRequest = Number(amount.value)
         const amountPlannedValue = paymentObject.amountPlanned.centAmount
         const currencyInMakePaymentRequest = amount.currency
         const currencyInAmountPlanned = paymentObject.amountPlanned.currencyCode


### PR DESCRIPTION
`amountInMakePaymentRequest` should be convert to Number before checking, because it comes from parsed string.
It is a fix for error:
```
{
        "code": "InvalidField",
        "message": "amountPlanned field must be the same as the amount in makePaymentRequest in the interface interactions or makePaymentRequest  in the custom field"
}
```
this PR is related to my opened issue: https://github.com/commercetools/commercetools-adyen-integration/issues/807