### PR TITLE
Fix klarna e2e test

### DIFF
--- a/extension/test/e2e/klarna.spec.js
+++ b/extension/test/e2e/klarna.spec.js
@@ -144,7 +144,6 @@ describe('::klarnaPayment::', () => {
       )
     } catch (err) {
       logger.error('klarna::makePaymentRequest::errors', JSON.stringify(err))
-      throw err
     } finally {
       const endTime = new Date().getTime()
       logger.debug('klarna::makePayment:', endTime - startTime)
@@ -200,7 +199,6 @@ describe('::klarnaPayment::', () => {
         'klarna::submitAdditionalPaymentDetailsRequest::errors',
         JSON.stringify(err)
       )
-      throw err
     } finally {
       const endTime = new Date().getTime()
       logger.debug('klarna::handleRedirect:', endTime - startTime)
@@ -228,7 +226,6 @@ describe('::klarnaPayment::', () => {
       )
     } catch (err) {
       logger.error('klarna::capturePaymentRequest::errors', JSON.stringify(err))
-      throw err
     } finally {
       const endTime = new Date().getTime()
       logger.debug('klarna::capturePayment:', endTime - startTime)

--- a/extension/test/e2e/klarna.spec.js
+++ b/extension/test/e2e/klarna.spec.js
@@ -78,7 +78,10 @@ describe('::klarnaPayment::', () => {
           ctpProjectKey
         )
         const endTime = new Date().getTime()
-        logger.debug('klarna::createPayment:', endTime - startTime)
+        logger.debug(
+          'klarna::createPayment::elapsedMilliseconds:',
+          endTime - startTime
+        )
 
         const browserTab = await browser.newPage()
         logger.debug('klarna::payment:', JSON.stringify(payment))
@@ -146,7 +149,10 @@ describe('::klarnaPayment::', () => {
       logger.error('klarna::makePaymentRequest::errors', JSON.stringify(err))
     } finally {
       const endTime = new Date().getTime()
-      logger.debug('klarna::makePayment:', endTime - startTime)
+      logger.debug(
+        'klarna::makePayment::elapsedMilliseconds:',
+        endTime - startTime
+      )
     }
     return result.body
   }
@@ -201,7 +207,10 @@ describe('::klarnaPayment::', () => {
       )
     } finally {
       const endTime = new Date().getTime()
-      logger.debug('klarna::handleRedirect:', endTime - startTime)
+      logger.debug(
+        'klarna::handleRedirect::elapsedMilliseconds:',
+        endTime - startTime
+      )
     }
     return result.body
   }
@@ -228,7 +237,10 @@ describe('::klarnaPayment::', () => {
       logger.error('klarna::capturePaymentRequest::errors', JSON.stringify(err))
     } finally {
       const endTime = new Date().getTime()
-      logger.debug('klarna::capturePayment:', endTime - startTime)
+      logger.debug(
+        'klarna::capturePayment::elapsedMilliseconds:',
+        endTime - startTime
+      )
     }
     return result.body
   }

--- a/extension/test/e2e/klarna.spec.js
+++ b/extension/test/e2e/klarna.spec.js
@@ -71,11 +71,14 @@ describe('::klarnaPayment::', () => {
       try {
         const baseUrl = config.getModuleConfig().apiExtensionBaseUrl
         const clientKey = config.getAdyenConfig(adyenMerchantAccount).clientKey
+        const startTime = new Date().getTime()
         const payment = await createPayment(
           ctpClient,
           adyenMerchantAccount,
           ctpProjectKey
         )
+        const endTime = new Date().getTime()
+        logger.debug('klarna::createPayment:', endTime - startTime)
 
         const browserTab = await browser.newPage()
         logger.debug('klarna::payment:', JSON.stringify(payment))
@@ -109,7 +112,7 @@ describe('::klarnaPayment::', () => {
           JSON.stringify(paymentAfterCapture)
         )
       } catch (err) {
-        logger.error('klarna::errors', JSON.stringify(err))
+        logger.error('klarna::errors', err)
       }
       assertManualCaptureResponse(paymentAfterCapture)
     }
@@ -139,6 +142,9 @@ describe('::klarnaPayment::', () => {
           },
         ]
       )
+    } catch (err) {
+      logger.error('klarna::makePaymentRequest::errors', JSON.stringify(err))
+      throw err
     } finally {
       const endTime = new Date().getTime()
       logger.debug('klarna::makePayment:', endTime - startTime)
@@ -162,8 +168,6 @@ describe('::klarnaPayment::', () => {
       browserTab.waitForSelector('#buy-button:not([disabled])'),
     ])
 
-    // Set 10 seconds to process Klarna Page
-    await browserTab.waitForTimeout(10_000)
     const klarnaPage = new KlarnaPage(browserTab)
 
     await Promise.all([
@@ -191,6 +195,12 @@ describe('::klarnaPayment::', () => {
           },
         ]
       )
+    } catch (err) {
+      logger.error(
+        'klarna::submitAdditionalPaymentDetailsRequest::errors',
+        JSON.stringify(err)
+      )
+      throw err
     } finally {
       const endTime = new Date().getTime()
       logger.debug('klarna::handleRedirect:', endTime - startTime)
@@ -216,6 +226,9 @@ describe('::klarnaPayment::', () => {
           }),
         ]
       )
+    } catch (err) {
+      logger.error('klarna::capturePaymentRequest::errors', JSON.stringify(err))
+      throw err
     } finally {
       const endTime = new Date().getTime()
       logger.debug('klarna::capturePayment:', endTime - startTime)

--- a/extension/test/e2e/pageObjects/KlarnaPage.js
+++ b/extension/test/e2e/pageObjects/KlarnaPage.js
@@ -8,10 +8,8 @@ module.exports = class KlarnaPage {
     const confirmationFrame = this.page
       .frames()
       .find((f) => f.name() === 'klarna-hpp-instance-fullscreen')
-    await confirmationFrame.waitForSelector(
-      '#iban'
-    )
-    await confirmationFrame.type('#iban','DE11520513735120710131') // Testing IBAN provided by Klarna
+    await confirmationFrame.waitForSelector('#iban')
+    await confirmationFrame.type('#iban', 'DE11520513735120710131') // Testing IBAN provided by Klarna
     await confirmationFrame.click('#aligned-content__button__0')
     await this.page.waitForTimeout(500)
     return confirmationFrame.click('#aligned-content__button__0')

--- a/extension/test/e2e/pageObjects/KlarnaPage.js
+++ b/extension/test/e2e/pageObjects/KlarnaPage.js
@@ -4,6 +4,12 @@ module.exports = class KlarnaPage {
   }
 
   async finishKlarnaPayment() {
+    // Wait for Klarna page being totally loaded
+    const klarnaMainFrame = this.page
+      .frames()
+      .find((f) => f.name() === 'klarna-hpp-instance-main')
+    await klarnaMainFrame.waitForSelector('#payment-method-selector')
+
     await this.page.click('#buy-button')
     const confirmationFrame = this.page
       .frames()
@@ -11,7 +17,10 @@ module.exports = class KlarnaPage {
     await confirmationFrame.waitForSelector('#iban')
     await confirmationFrame.type('#iban', 'DE11520513735120710131') // Testing IBAN provided by Klarna
     await confirmationFrame.click('#aligned-content__button__0')
-    await this.page.waitForTimeout(500)
+
+    // Suspend two seconds to wait for iframe page refresh
+    await confirmationFrame.waitForTimeout(2_000)
+
     return confirmationFrame.click('#aligned-content__button__0')
   }
 }

--- a/extension/test/e2e/pageObjects/KlarnaPage.js
+++ b/extension/test/e2e/pageObjects/KlarnaPage.js
@@ -9,8 +9,11 @@ module.exports = class KlarnaPage {
       .frames()
       .find((f) => f.name() === 'klarna-hpp-instance-fullscreen')
     await confirmationFrame.waitForSelector(
-      '#mandate-review__confirmation-button'
+      '#iban'
     )
-    return confirmationFrame.click('#mandate-review__confirmation-button')
+    await confirmationFrame.type('#iban','DE11520513735120710131') // Testing IBAN provided by Klarna
+    await confirmationFrame.click('#aligned-content__button__0')
+    await this.page.waitForTimeout(500)
+    return confirmationFrame.click('#aligned-content__button__0')
   }
 }

--- a/extension/test/e2e/pageObjects/MakePaymentFormPage.js
+++ b/extension/test/e2e/pageObjects/MakePaymentFormPage.js
@@ -11,7 +11,7 @@ module.exports = class MakePaymentFormPage {
   async generateAdyenMakePaymentForm(clientKey) {
     await this.page.type('#adyen-client-key', clientKey)
     await this.page.$eval('#adyen-client-key', (e) => e.blur())
-    await this.page.waitForTimeout(10_000)
+    await this.page.waitForTimeout(2_000)
   }
 
   async getMakePaymentRequestTextAreaValue() {


### PR DESCRIPTION
**Situation**
We have e2e test for Klarna payment

**Complication**
Recently a new IBAN input field is added in Klarna page. It didn't exist before so we don't handle it in our web test, which cause e2e test failure in these days.

**Resolution**
Autofill the IBAN input field in e2e test

**Hints for reviewer**
- Add auto-filling for new IBAN input field.
- Enhance the error logging in klarna payment e2e test
- Change from `page.waitForTimeout(...)` to `frame.waitForSelector(...)` to ensure Klarna payment page is completely loaded