### PR TITLE
Use the concurrency keyword to limit the ci concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: CI
+concurrency: CI
 
 on: [push]
 
@@ -15,12 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: serializing workflow runs
-        uses: softprops/turnstyle@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          same-branch-only: false
       - name: Use Node.js 14.x
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: CI
-concurrency: CI
 
 on: [push]
 
 jobs:
   extension_build:
     name: Extension Module
+    concurrency: extension_build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -28,6 +28,7 @@ jobs:
 
   notification_build:
     name: Notification Module
+    concurrency: notification_build
     needs: extension_build
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,6 @@ jobs:
         working-directory: notification
     steps:
       - uses: actions/checkout@v2
-      - name: serializing workflow runs
-        uses: softprops/turnstyle@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          same-branch-only: false
       - name: Use Node.js 14.x
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
Replacing turnstyle with concurrency.

Successfully tested that functionality on my project:

https://github.com/HollowMan6/LZU-Auto-COVID-Health-Report/blob/d23c4ac83fd5ae770595c1fda8ad1d66b7ceaa89/.github/workflows/autoreport.yml#L2

Test result: 
![20211001142530](https://user-images.githubusercontent.com/43995067/135576206-23dc5578-db81-4178-b561-52be242b97b2.png)
![20211001142544](https://user-images.githubusercontent.com/43995067/135576245-731259a1-6047-40ba-9573-ed8ce3c0e9b7.png)

Since I noticed that the `same-branch-only` is `false`, I didn't add `-${{ github.ref }}` in the group name.

Resolves #827 

Signed-off-by: Hollow Man <hollowman@hollowman.ml>