### PR TITLE
add get-carbon-offset-costs.handler and cover it with unit tests

### DIFF
--- a/extension/resources/web-components-payment-type.json
+++ b/extension/resources/web-components-payment-type.json
@@ -103,6 +103,28 @@
       },
       "inputHint": "SingleLine",
       "required": false
+    },
+    {
+      "name": "getCarbonOffsetCostsRequest",
+      "label": {
+        "en": "getCarbonOffsetCostsRequest"
+      },
+      "type": {
+        "name": "String"
+      },
+      "inputHint": "MultiLine",
+      "required": false
+    },
+    {
+      "name": "getCarbonOffsetCostsResponse",
+      "label": {
+        "en": "getCarbonOffsetCostsResponse"
+      },
+      "type": {
+        "name": "String"
+      },
+      "inputHint": "MultiLine",
+      "required": false
     }
   ]
 }

--- a/extension/src/config/config.js
+++ b/extension/src/config/config.js
@@ -4,7 +4,7 @@ function getModuleConfig() {
   let removeSensitiveData = config.removeSensitiveData !== 'false'
   if (config.removeSensitiveData === false) removeSensitiveData = false
 
-  const result = {
+  return {
     removeSensitiveData,
     port: config.port,
     logLevel: config.logLevel,
@@ -14,7 +14,6 @@ function getModuleConfig() {
       ? parseFloat(config.keepAliveTimeout, 10)
       : undefined,
   }
-  return result
 }
 
 function _validateAuthenticationConfig(ctpConfig) {

--- a/extension/src/config/constants.js
+++ b/extension/src/config/constants.js
@@ -23,4 +23,6 @@ module.exports = {
   ],
 
   PAYMENT_METHOD_TYPE_AFFIRM_METHODS: ['affirm'],
+  CTP_CARBON_OFFSET_COSTS_RESPONSE: 'getCarbonOffsetCostsResponse',
+  CTP_INTERACTION_TYPE_GET_CARBON_OFFSET_COSTS: 'getCarbonOffsetCosts',
 }

--- a/extension/src/paymentHandler/get-carbon-offset-costs.handler.js
+++ b/extension/src/paymentHandler/get-carbon-offset-costs.handler.js
@@ -1,0 +1,29 @@
+const pU = require('./payment-utils')
+const c = require('../config/constants')
+const { getCarbonOffsetCosts } = require('../service/web-component-service')
+
+async function execute(paymentObject) {
+  const getCarbonOffsetCostsRequestObj = JSON.parse(
+    paymentObject.custom.fields.getCarbonOffsetCostsRequest
+  )
+  const adyenMerchantAccount = paymentObject.custom.fields.adyenMerchantAccount
+  const { request, response } = await getCarbonOffsetCosts(
+    adyenMerchantAccount,
+    getCarbonOffsetCostsRequestObj
+  )
+  return {
+    actions: [
+      pU.createAddInterfaceInteractionAction({
+        request,
+        response,
+        type: c.CTP_INTERACTION_TYPE_GET_CARBON_OFFSET_COSTS,
+      }),
+      pU.createSetCustomFieldAction(
+        c.CTP_CARBON_OFFSET_COSTS_RESPONSE,
+        response
+      ),
+    ],
+  }
+}
+
+module.exports = { execute }

--- a/extension/src/paymentHandler/payment-handler.js
+++ b/extension/src/paymentHandler/payment-handler.js
@@ -6,6 +6,7 @@ const submitPaymentDetailsHandler = require('./submit-payment-details.handler')
 const manualCaptureHandler = require('./manual-capture.handler')
 const cancelHandler = require('./cancel-payment.handler')
 const refundHandler = require('./refund-payment.handler')
+const getCarbonOffsetCostsHandler = require('./get-carbon-offset-costs.handler')
 const pU = require('./payment-utils')
 const auth = require('../validator/authentication')
 const errorMessages = require('../validator/error-messages')
@@ -77,6 +78,11 @@ function _getPaymentHandlers(paymentObject) {
     !paymentObject.custom.fields.getPaymentMethodsResponse
   )
     handlers.push(getPaymentMethodsHandler)
+  if (
+    paymentObject.custom.fields.getCarbonOffsetCostsRequest &&
+    !paymentObject.custom.fields.getCarbonOffsetCostsResponse
+  )
+    handlers.push(getCarbonOffsetCostsHandler)
   if (
     paymentObject.custom.fields.makePaymentRequest &&
     !paymentObject.custom.fields.makePaymentResponse

--- a/extension/src/service/web-component-service.js
+++ b/extension/src/service/web-component-service.js
@@ -165,5 +165,5 @@ module.exports = {
   manualCapture,
   refund,
   cancelPayment,
-  getCarbonOffsetCosts
+  getCarbonOffsetCosts,
 }

--- a/extension/src/service/web-component-service.js
+++ b/extension/src/service/web-component-service.js
@@ -88,6 +88,16 @@ function refund(merchantAccount, commercetoolsProjectKey, refundRequestObj) {
   )
 }
 
+function getCarbonOffsetCosts(merchantAccount, getCarbonOffsetCostsRequestObj) {
+  const adyenCredentials = config.getAdyenConfig(merchantAccount)
+  return callAdyen(
+    `${adyenCredentials.apiBaseUrl}/carbonOffsetCosts`,
+    merchantAccount,
+    adyenCredentials.apiKey,
+    extendRequestObjWithApplicationInfo(getCarbonOffsetCostsRequestObj)
+  )
+}
+
 function extendRequestObjWithApplicationInfo(requestObj) {
   requestObj.applicationInfo = {
     merchantApplication: {
@@ -155,4 +165,5 @@ module.exports = {
   manualCapture,
   refund,
   cancelPayment,
+  getCarbonOffsetCosts
 }

--- a/extension/src/validator/error-messages.js
+++ b/extension/src/validator/error-messages.js
@@ -3,7 +3,6 @@ module.exports = {
     'getPaymentMethodsRequest does not contain valid JSON.',
   MAKE_PAYMENT_REQUEST_INVALID_JSON:
     'makePaymentRequest does not contain valid JSON.',
-  // eslint-disable-next-line max-len
   SUBMIT_ADDITIONAL_PAYMENT_DETAILS_REQUEST_INVALID_JSON:
     'submitAdditionalPaymentDetailsRequest does not contain valid JSON.',
   AMOUNT_PLANNED_NOT_SAME:

--- a/extension/src/validator/error-messages.js
+++ b/extension/src/validator/error-messages.js
@@ -18,4 +18,6 @@ module.exports = {
   UNAUTHORIZED_REQUEST: 'The request is unauthorized.',
   MISSING_CREDENTIAL:
     'Credential is missing in required project configuration.',
+  GET_CARBON_OFFSET_COSTS_REQUEST_INVALID_JSON:
+    'getCarbonOffsetCostsRequest does not contain valid JSON.',
 }

--- a/extension/src/validator/validator-builder.js
+++ b/extension/src/validator/validator-builder.js
@@ -44,7 +44,9 @@ function withPayment(paymentObject) {
       )
         errors.submitAdditionalPaymentDetailsRequest =
           errorMessages.SUBMIT_ADDITIONAL_PAYMENT_DETAILS_REQUEST_INVALID_JSON
-      if (!pU.isValidJSON(paymentObject.custom.fields.getCarbonOffsetCostsRequest))
+      if (
+        !pU.isValidJSON(paymentObject.custom.fields.getCarbonOffsetCostsRequest)
+      )
         errors.getCarbonOffsetCostsRequest =
           errorMessages.GET_CARBON_OFFSET_COSTS_REQUEST_INVALID_JSON
       return this

--- a/extension/src/validator/validator-builder.js
+++ b/extension/src/validator/validator-builder.js
@@ -44,6 +44,9 @@ function withPayment(paymentObject) {
       )
         errors.submitAdditionalPaymentDetailsRequest =
           errorMessages.SUBMIT_ADDITIONAL_PAYMENT_DETAILS_REQUEST_INVALID_JSON
+      if (!pU.isValidJSON(paymentObject.custom.fields.getCarbonOffsetCostsRequest))
+        errors.getCarbonOffsetCostsRequest =
+          errorMessages.GET_CARBON_OFFSET_COSTS_REQUEST_INVALID_JSON
       return this
     },
     validateReference() {

--- a/extension/test/unit/get-carbon-offset-costs.handler.spec.js
+++ b/extension/test/unit/get-carbon-offset-costs.handler.spec.js
@@ -13,9 +13,9 @@ describe('get-carbon-offset-costs::execute::', () => {
     originCountry: 'BE',
     deliveryCountry: 'FR',
     packageWeight: {
-      value: 2.20,
-      unit: 'kg'
-    }
+      value: 2.2,
+      unit: 'kg',
+    },
   }
 
   const paymentObject = {
@@ -34,7 +34,9 @@ describe('get-carbon-offset-costs::execute::', () => {
       },
       fields: {
         commercetoolsProjectKey: 'commercetoolsProjectKey',
-        getCarbonOffsetCostsRequest: JSON.stringify(getCarbonOffsetCostsRequest),
+        getCarbonOffsetCostsRequest: JSON.stringify(
+          getCarbonOffsetCostsRequest
+        ),
         adyenMerchantAccount,
       },
     },
@@ -48,12 +50,12 @@ describe('get-carbon-offset-costs::execute::', () => {
     const getCarbonOffsetCostsResponse = {
       deliveryOffset: {
         currency: 'EUR',
-        value: 12
+        value: 12,
       },
       totalOffset: {
         currency: 'EUR',
-        value: 12
-      }
+        value: 12,
+      },
     }
 
     sinon
@@ -77,9 +79,7 @@ describe('get-carbon-offset-costs::execute::', () => {
     expect(result.actions[0].fields.type).to.equal(
       c.CTP_INTERACTION_TYPE_GET_CARBON_OFFSET_COSTS
     )
-    expect(result.actions[1].name).to.equal(
-      c.CTP_CARBON_OFFSET_COSTS_RESPONSE
-    )
+    expect(result.actions[1].name).to.equal(c.CTP_CARBON_OFFSET_COSTS_RESPONSE)
   })
 
   it(

--- a/extension/test/unit/get-carbon-offset-costs.handler.spec.js
+++ b/extension/test/unit/get-carbon-offset-costs.handler.spec.js
@@ -1,0 +1,109 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+const fetch = require('node-fetch')
+const c = require('../../src/config/constants')
+const {
+  execute,
+} = require('../../src/paymentHandler/get-carbon-offset-costs.handler')
+const config = require('../../src/config/config')
+
+describe('get-carbon-offset-costs::execute::', () => {
+  const adyenMerchantAccount = config.getAllAdyenMerchantAccounts()[0]
+  const getCarbonOffsetCostsRequest = {
+    originCountry: 'BE',
+    deliveryCountry: 'FR',
+    packageWeight: {
+      value: 2.20,
+      unit: 'kg'
+    }
+  }
+
+  const paymentObject = {
+    amountPlanned: {
+      currencyCode: 'EUR',
+      centAmount: 1000,
+    },
+    paymentMethodInfo: {
+      paymentInterface: c.CTP_ADYEN_INTEGRATION,
+    },
+    interfaceInteractions: [],
+    custom: {
+      type: {
+        typeId: 'type',
+        key: c.CTP_PAYMENT_CUSTOM_TYPE_KEY,
+      },
+      fields: {
+        commercetoolsProjectKey: 'commercetoolsProjectKey',
+        getCarbonOffsetCostsRequest: JSON.stringify(getCarbonOffsetCostsRequest),
+        adyenMerchantAccount,
+      },
+    },
+  }
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('handlePayment should return the right actions', async () => {
+    const getCarbonOffsetCostsResponse = {
+      deliveryOffset: {
+        currency: 'EUR',
+        value: 12
+      },
+      totalOffset: {
+        currency: 'EUR',
+        value: 12
+      }
+    }
+
+    sinon
+      .stub(fetch, 'Promise')
+      .resolves({ json: () => getCarbonOffsetCostsResponse })
+
+    const result = await execute(paymentObject)
+
+    expect(result.actions.length).to.equal(2)
+    expect(result.actions[0].action).to.equal('addInterfaceInteraction')
+    expect(result.actions[1].action).to.equal('setCustomField')
+    expect(JSON.parse(result.actions[0].fields.request)).to.be.deep.includes(
+      getCarbonOffsetCostsRequest
+    )
+    expect(result.actions[0].fields.response).to.be.deep.equal(
+      JSON.stringify(getCarbonOffsetCostsResponse)
+    )
+    expect(result.actions[0].fields.response).to.be.deep.equal(
+      result.actions[1].value
+    )
+    expect(result.actions[0].fields.type).to.equal(
+      c.CTP_INTERACTION_TYPE_GET_CARBON_OFFSET_COSTS
+    )
+    expect(result.actions[1].name).to.equal(
+      c.CTP_CARBON_OFFSET_COSTS_RESPONSE
+    )
+  })
+
+  it(
+    'when adyen request fails ' +
+      'then handlePayment should return the right actions with failed responses',
+    async () => {
+      const errorMsg = 'unexpected exception'
+      sinon.stub(fetch, 'Promise').rejects(errorMsg)
+
+      const result = await execute(paymentObject)
+
+      expect(result.actions.length).to.equal(2)
+      expect(result.actions[0].action).to.equal('addInterfaceInteraction')
+      expect(result.actions[1].action).to.equal('setCustomField')
+      expect(JSON.parse(result.actions[0].fields.request)).to.be.deep.includes(
+        getCarbonOffsetCostsRequest
+      )
+      expect(result.actions[0].fields.response).to.be.includes(errorMsg)
+      expect(result.actions[0].fields.type).to.equal(
+        c.CTP_INTERACTION_TYPE_GET_CARBON_OFFSET_COSTS
+      )
+      expect(result.actions[1].name).to.equal(
+        c.CTP_CARBON_OFFSET_COSTS_RESPONSE
+      )
+    }
+  )
+})

--- a/extension/test/unit/validator-builder.spec.js
+++ b/extension/test/unit/validator-builder.spec.js
@@ -9,7 +9,7 @@ const {
   MAKE_PAYMENT_REQUEST_MISSING_REFERENCE,
   MISSING_REQUIRED_FIELDS_ADYEN_MERCHANT_ACCOUNT,
   MISSING_REQUIRED_FIELDS_CTP_PROJECT_KEY,
-  GET_CARBON_OFFSET_COSTS_REQUEST_INVALID_JSON
+  GET_CARBON_OFFSET_COSTS_REQUEST_INVALID_JSON,
 } = require('../../src/validator/error-messages')
 
 describe('Validator builder', () => {
@@ -21,7 +21,7 @@ describe('Validator builder', () => {
           getPaymentMethodsRequest: invalidJSONContent,
           makePaymentRequest: invalidJSONContent,
           submitAdditionalPaymentDetailsRequest: invalidJSONContent,
-          getCarbonOffsetCostsRequest: invalidJSONContent
+          getCarbonOffsetCostsRequest: invalidJSONContent,
         },
       },
     }

--- a/extension/test/unit/validator-builder.spec.js
+++ b/extension/test/unit/validator-builder.spec.js
@@ -9,16 +9,19 @@ const {
   MAKE_PAYMENT_REQUEST_MISSING_REFERENCE,
   MISSING_REQUIRED_FIELDS_ADYEN_MERCHANT_ACCOUNT,
   MISSING_REQUIRED_FIELDS_CTP_PROJECT_KEY,
+  GET_CARBON_OFFSET_COSTS_REQUEST_INVALID_JSON
 } = require('../../src/validator/error-messages')
 
 describe('Validator builder', () => {
   it('on invalid JSON validateRequestFields() should return error object', () => {
+    const invalidJSONContent = '{"a"}'
     const invalidPayment = {
       custom: {
         fields: {
-          getPaymentMethodsRequest: '{"a"}',
-          makePaymentRequest: '{"a"}',
-          submitAdditionalPaymentDetailsRequest: '{"a"}',
+          getPaymentMethodsRequest: invalidJSONContent,
+          makePaymentRequest: invalidJSONContent,
+          submitAdditionalPaymentDetailsRequest: invalidJSONContent,
+          getCarbonOffsetCostsRequest: invalidJSONContent
         },
       },
     }
@@ -31,6 +34,9 @@ describe('Validator builder', () => {
     expect(errorObject[1].message).to.equal(MAKE_PAYMENT_REQUEST_INVALID_JSON)
     expect(errorObject[2].message).to.equal(
       SUBMIT_ADDITIONAL_PAYMENT_DETAILS_REQUEST_INVALID_JSON
+    )
+    expect(errorObject[3].message).to.equal(
+      GET_CARBON_OFFSET_COSTS_REQUEST_INVALID_JSON
     )
   })
 


### PR DESCRIPTION
Overview: https://www.adyen.com/social-responsibility/impact#restore

Concept: Offset information will be requested through our adyen integration, integration user will set a custom field and we will call Adyen API and set it back to response custom field. This needs to be before the makePaymentRequest. 

PR addresses the offset calculation only. Integration tests and documentation will be added part of another task.