### PR TITLE
Make metadata extendible

### DIFF
--- a/extension/src/service/web-component-service.js
+++ b/extension/src/service/web-component-service.js
@@ -116,7 +116,7 @@ function extendRequestObjWithMetadata(requestObj, commercetoolsProjectKey) {
   if (requestObj.metadata) {
     requestObj.metadata = {
       ...requestObj.metadata,
-      ctProjectKey: commercetoolsProjectKey
+      ctProjectKey: commercetoolsProjectKey,
     }
   } else {
     requestObj.metadata = {

--- a/extension/src/service/web-component-service.js
+++ b/extension/src/service/web-component-service.js
@@ -113,10 +113,17 @@ function extendRequestObjWithApplicationInfo(requestObj) {
 }
 
 function extendRequestObjWithMetadata(requestObj, commercetoolsProjectKey) {
-  requestObj.metadata = {
-    // metadata key must have length of max. 20 chars
-    // metadata value must have length of max. 80 chars
-    ctProjectKey: commercetoolsProjectKey,
+  if (requestObj.metadata) {
+    requestObj.metadata = {
+      ...requestObj.metadata,
+      ctProjectKey: commercetoolsProjectKey
+    }
+  } else {
+    requestObj.metadata = {
+      // metadata key must have length of max. 20 chars
+      // metadata value must have length of max. 80 chars
+      ctProjectKey: commercetoolsProjectKey,
+    }
   }
 }
 

--- a/extension/test/integration/make-payment.handler.spec.js
+++ b/extension/test/integration/make-payment.handler.spec.js
@@ -33,6 +33,10 @@ describe('::make-payment with multiple adyen accounts use case::', () => {
         makePayment({
           reference: 'paymentFromMerchant1',
           adyenMerchantAccount: adyenMerchantAccount1,
+          metadata: {
+            orderNumber: `externalOrderSystem-12345`,
+            receiptNumber: `externalOrderSystem-receipt123`
+          }
         }),
         makePayment({
           reference: 'paymentFromMerchant2',
@@ -42,7 +46,7 @@ describe('::make-payment with multiple adyen accounts use case::', () => {
     }
   )
 
-  async function makePayment({ reference, adyenMerchantAccount }) {
+  async function makePayment({ reference, adyenMerchantAccount, metadata }) {
     const makePaymentRequestDraft = {
       amount: {
         currency: 'EUR',
@@ -56,6 +60,7 @@ describe('::make-payment with multiple adyen accounts use case::', () => {
         encryptedExpiryYear: 'test_2030',
         encryptedSecurityCode: 'test_737',
       },
+      metadata,
       returnUrl: 'https://your-company.com/',
     }
     const paymentDraft = {
@@ -95,7 +100,7 @@ describe('::make-payment with multiple adyen accounts use case::', () => {
         interaction.fields.type === constants.CTP_INTERACTION_TYPE_MAKE_PAYMENT
     )
     const makePaymentRequest = JSON.parse(interfaceInteraction.fields.request)
-    expect(makePaymentRequest.metadata).to.deep.equal({
+    expect(makePaymentRequest.metadata).to.deep.include({
       ctProjectKey: commercetoolsProjectKey,
     })
     expect(makePaymentRequest.merchantAccount).to.be.equal(adyenMerchantAccount)

--- a/extension/test/integration/make-payment.handler.spec.js
+++ b/extension/test/integration/make-payment.handler.spec.js
@@ -35,8 +35,8 @@ describe('::make-payment with multiple adyen accounts use case::', () => {
           adyenMerchantAccount: adyenMerchantAccount1,
           metadata: {
             orderNumber: `externalOrderSystem-12345`,
-            receiptNumber: `externalOrderSystem-receipt123`
-          }
+            receiptNumber: `externalOrderSystem-receipt123`,
+          },
         }),
         makePayment({
           reference: 'paymentFromMerchant2',


### PR DESCRIPTION
Addresses: #881 

Example notification payload, (see metadata fields on additionalData):

````json
{
  "NotificationRequestItem": {
    "additionalData": {
      "cvcResult": "1 Matches",
      "expiryDate": "03/2030",
      "metadata.orderNumber": "externalOrderSystem-12345",
      "authCode": "094419",
      "avsResult": "5 No AVS data provided",
      "cardSummary": "1111",
      "metadata.ctProjectKey": "test",
      "authorisationMid": "1000",
      "hmacSignature": "Z/v",
      "acquirerAccountCode": "TestPmmAcquirerAccount",
      "metadata.receiptNumber": "externalOrderSystem-receipt123"
    },
    "amount": {
      "currency": "EUR",
      "value": 1000
    },
    "eventCode": "AUTHORISATION",
    "eventDate": "2021-12-15T09:58:29+01:00",
    "merchantAccountCode": "Adyen-ctp-qa-01",
    "merchantReference": "dfdsfsdfsdc",
    "operations": [
      "CANCEL",
      "CAPTURE",
      "REFUND"
    ],
    "paymentMethod": "visa",
    "pspReference": "852639558709915E",
    "reason": "0000:1111:03/2030",
    "success": "true"
  }
}
````
