### PR TITLE
Fix 3DS native test

### DIFF
--- a/extension/test/e2e/affirm.spec.js
+++ b/extension/test/e2e/affirm.spec.js
@@ -16,7 +16,7 @@ const RedirectPaymentFormPage = require('./pageObjects/RedirectPaymentFormPage')
 const AffirmPage = require('./pageObjects/AffirmPage')
 
 // Flow description: https://docs.adyen.com/payment-methods/affirm/web-component#page-introduction
-describe.skip('::affirmPayment::', () => {
+describe('::affirmPayment::', () => {
   let browser
   let ctpClient
   const adyenMerchantAccount = config.getAllAdyenMerchantAccounts()[0]

--- a/extension/test/e2e/credit-card-3ds-native.spec.js
+++ b/extension/test/e2e/credit-card-3ds-native.spec.js
@@ -15,7 +15,7 @@ const RedirectPaymentFormPage = require('./pageObjects/RedirectPaymentFormPage')
 const CreditCardNativePage = require('./pageObjects/CreditCard3dsNativePage')
 
 // Flow description: https://docs.adyen.com/checkout/3d-secure/native-3ds2/web-component
-describe.skip('::creditCardPayment3dsNative::', () => {
+describe('::creditCardPayment3dsNative::', () => {
   let browser
   let ctpClient
   const adyenMerchantAccount = config.getAllAdyenMerchantAccounts()[0]
@@ -88,6 +88,7 @@ describe.skip('::creditCardPayment3dsNative::', () => {
           payment: paymentAfterMakePayment,
           browserTab,
           baseUrl,
+          clientKey
         })
         logger.debug(
           'credit-card-3ds-native::paymentAfterAuthentication:',
@@ -132,7 +133,7 @@ describe.skip('::creditCardPayment3dsNative::', () => {
     return payment
   }
 
-  async function performChallengeFlow({ payment, browserTab, baseUrl }) {
+  async function performChallengeFlow({ payment, browserTab, baseUrl, clientKey }) {
     // Submit additional details 1
     const { makePaymentResponse: makePaymentResponseString } =
       payment.custom.fields
@@ -143,7 +144,7 @@ describe.skip('::creditCardPayment3dsNative::', () => {
     )
     await redirectPaymentFormPage.goToThisPage()
     await redirectPaymentFormPage.redirectToAdyenPaymentPage(
-      makePaymentResponse
+      makePaymentResponse, clientKey
     )
 
     await browserTab.waitForTimeout(5_000)

--- a/extension/test/e2e/credit-card-3ds-native.spec.js
+++ b/extension/test/e2e/credit-card-3ds-native.spec.js
@@ -88,7 +88,7 @@ describe('::creditCardPayment3dsNative::', () => {
           payment: paymentAfterMakePayment,
           browserTab,
           baseUrl,
-          clientKey
+          clientKey,
         })
         logger.debug(
           'credit-card-3ds-native::paymentAfterAuthentication:',
@@ -133,7 +133,12 @@ describe('::creditCardPayment3dsNative::', () => {
     return payment
   }
 
-  async function performChallengeFlow({ payment, browserTab, baseUrl, clientKey }) {
+  async function performChallengeFlow({
+    payment,
+    browserTab,
+    baseUrl,
+    clientKey,
+  }) {
     // Submit additional details 1
     const { makePaymentResponse: makePaymentResponseString } =
       payment.custom.fields
@@ -144,7 +149,8 @@ describe('::creditCardPayment3dsNative::', () => {
     )
     await redirectPaymentFormPage.goToThisPage()
     await redirectPaymentFormPage.redirectToAdyenPaymentPage(
-      makePaymentResponse, clientKey
+      makePaymentResponse,
+      clientKey
     )
 
     await browserTab.waitForTimeout(5_000)

--- a/extension/test/e2e/e2e-test-utils.js
+++ b/extension/test/e2e/e2e-test-utils.js
@@ -23,7 +23,7 @@ async function executeInAdyenIframe(page, selector, executeFn) {
   for (const frame of page.mainFrame().childFrames()) {
     const elementHandle = await frame.$(selector)
     if (elementHandle) {
-      await executeFn(elementHandle)
+      await executeFn(elementHandle, frame)
       break
     }
   }

--- a/extension/test/e2e/pageObjects/CreditCard3dsNativePage.js
+++ b/extension/test/e2e/pageObjects/CreditCard3dsNativePage.js
@@ -11,9 +11,9 @@ module.exports = class CreditCard3dsNativePage {
       el.type('password')
     )
     await executeInAdyenIframe(this.page, 'button[type=submit]', (el, frame) =>
-        frame.$eval('#buttonSubmit', async (button) => {
-          await button.click()
-        })
+      frame.$eval('#buttonSubmit', async (button) => {
+        await button.click()
+      })
     )
 
     await this.page.waitForTimeout(1_000)

--- a/extension/test/e2e/pageObjects/CreditCard3dsNativePage.js
+++ b/extension/test/e2e/pageObjects/CreditCard3dsNativePage.js
@@ -10,11 +10,13 @@ module.exports = class CreditCard3dsNativePage {
     await executeInAdyenIframe(this.page, '[name=answer]', (el) =>
       el.type('password')
     )
-    await executeInAdyenIframe(this.page, 'button[type=submit]', (el) =>
-      el.click()
+    await executeInAdyenIframe(this.page, 'button[type=submit]', (el, frame) =>
+        frame.$eval('#buttonSubmit', async (button) => {
+          await button.click()
+        })
     )
 
-    await this.page.waitForTimeout(15_000)
+    await this.page.waitForTimeout(1_000)
 
     const additionalPaymentDetailsInput2 = await this.page.$(
       '#adyen-additional-payment-details'

--- a/extension/test/e2e/pageObjects/RedirectPaymentFormPage.js
+++ b/extension/test/e2e/pageObjects/RedirectPaymentFormPage.js
@@ -25,9 +25,7 @@ module.exports = class RedirectPaymentFormPage {
       JSON.stringify(paymentDetailsResponse.action)
     )
 
-    await pasteValue(
-      this.page, '#adyen-client-key', clientKey
-    )
+    await pasteValue(this.page, '#adyen-client-key', clientKey)
     return this.page.click('#redirect-payment-button')
   }
 }

--- a/extension/test/e2e/pageObjects/RedirectPaymentFormPage.js
+++ b/extension/test/e2e/pageObjects/RedirectPaymentFormPage.js
@@ -14,7 +14,7 @@ module.exports = class RedirectPaymentFormPage {
     await this.page.goto(`${this.baseUrl}/redirect-payment-form`)
   }
 
-  async redirectToAdyenPaymentPage(paymentDetailsResponse) {
+  async redirectToAdyenPaymentPage(paymentDetailsResponse, clientKey) {
     logger.debug(
       'redirectToAdyenPaymentPage::paymentDetailsResponse::',
       paymentDetailsResponse
@@ -23,6 +23,10 @@ module.exports = class RedirectPaymentFormPage {
       this.page,
       '#adyen-make-payment-response-action-field',
       JSON.stringify(paymentDetailsResponse.action)
+    )
+
+    await pasteValue(
+      this.page, '#adyen-client-key', clientKey
     )
     return this.page.click('#redirect-payment-button')
   }


### PR DESCRIPTION
The problems:

- 3DS native now requires clientKey, so I added it. 

- Additionally somehow the test could not click on one button in the iframe anymore. I had to update the clicking mechanism to make it work.

- Affirm seems to be working fine, so there is no fix needed.