### PR TITLE
change the structure of describing environment variables on how to run docs.

### DIFF
--- a/extension/docs/HowToRun.md
+++ b/extension/docs/HowToRun.md
@@ -62,7 +62,11 @@ Extension module requires 1 environment variable to start. This environment vari
 }
 ```
 
-> Note that multiple child attributes can be provided in the `adyen` and `commercetools` attribute group. Other configurations can be set as direct child attributes in `ADYEN_INTEGRATION_CONFIG`.
+`ADYEN_INTEGRATION_CONFIG` JSON structure contains different `attribute groups` as described below:
+
+- `adyen` attribute group: Multiple child attributes can be provided in the `adyen` attribute. Each direct child attribute must represent an adyen merchant account.
+- `commercetools` attribute group: Multiple child attributes can be provided in the `commercetools` attribute. Each direct child attribute must represent a commercetools project.
+- `other` attribute group: Attributes in this group can be set as direct child attributes in `the root of the JSON`.
 
 #### Preparing the credentials
 

--- a/extension/docs/HowToRun.md
+++ b/extension/docs/HowToRun.md
@@ -62,7 +62,7 @@ Extension module requires 1 environment variable to start. This environment vari
 }
 ```
 
-> Note that, multiple child attributes can be provided in the `adyen` and `commercetools` attribute group. Other configurations can be set as direct child attributes in `ADYEN_INTEGRATION_CONFIG`.
+> Note that multiple child attributes can be provided in the `adyen` and `commercetools` attribute group. Other configurations can be set as direct child attributes in `ADYEN_INTEGRATION_CONFIG`.
 
 #### Preparing the credentials
 
@@ -71,7 +71,7 @@ Extension module requires 1 environment variable to start. This environment vari
   - For **live environment** follow the official Adyen [documentation](https://docs.adyen.com/user-management/get-started-with-adyen#step-2-apply-for-your-live-account) for details.
 - commercetools project credentials:
   - If you don't have the commercetools OAuth credentials,[create a commercetools API Client](https://docs.commercetools.com/getting-started.html#create-an-api-client).
-    - Note that, extension module requires `manage_payments, view_orders` [scopes](https://docs.commercetools.com/http-api-scopes) for the integration and `manage_types, manage_extensions` [scopes](https://docs.commercetools.com/http-api-scopes) for setting up required resources.
+    - Note that extension module requires `manage_payments, view_orders` [scopes](https://docs.commercetools.com/http-api-scopes) for the integration and `manage_types, manage_extensions` [scopes](https://docs.commercetools.com/http-api-scopes) for setting up required resources.
 
 ### Required attributes
 

--- a/extension/docs/HowToRun.md
+++ b/extension/docs/HowToRun.md
@@ -4,9 +4,9 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Environment variable](#environment-variable)
-  - [Adyen](#adyen)
-  - [commercetools](#commercetools)
-  - [Other Configurations](#other-configurations)
+  - [Preparing the credentials](#preparing-the-credentials)
+  - [Required attributes](#required-attributes)
+  - [Optional attributes](#optional-attributes)
   - [External file configuration](#external-file-configuration)
 - [Commercetools project requirements](#commercetools-project-requirements)
 - [Other requirements](#other-requirements)
@@ -43,113 +43,60 @@ Extension module requires 1 environment variable to start. This environment vari
     }
   },
   "adyenPaymentMethodsToNames": {
-    "visa": { "en": "Credit card visa" },
-    "gpay": { "en": "Google Pay" }
-  }
-}
-```
-
-The JSON structure will be described in details in the next sections of this documentation.
-
-### Adyen
-
-- For **test environment** follow the official Adyen [get started guide](https://docs.adyen.com/checkout/get-started) to set up your **test account**, get your API key.
-- For **live environment** follow the official Adyen [documentation](https://docs.adyen.com/user-management/get-started-with-adyen#step-2-apply-for-your-live-account) for details.
-
-Multiple child attributes can be provided in the `adyen` attribute. Each direct child attribute must represent 1 adyen merchant account like in the following example:
-
-```
-{
-  "adyen": {
-    "adyenMerchantAccount1": {  // The name of your first merchant account.
-      "apiKey": "xxx"
-      "apiBaseUrl": "https://checkout-test.adyen.com/v65",
-      "legacyApiBaseUrl": "https://pal-test.adyen.com/pal/servlet/Payment/v65"
+    "scheme": {
+      "en": "Credit Card"
     },
-    "adyenMerchantAccount2": {  // The name of your second merchant account.
-      "apiKey": "xxx"
+    "pp": {
+      "en": "PayPal"
+    },
+    "klarna": {
+      "en": "Klarna"
+    },
+    "gpay": {
+      "en": "Google Pay"
+    },
+    "affirm": {
+      "en": "Affirm"
     }
   }
 }
 ```
 
-| Name               | Content                                                                                                                                                  | Required | Default value (only for test environment)                                                                                                                                           |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `apiKey`           | You'll be making API requests that are authenticated with an [API key](https://docs.adyen.com/user-management/how-to-get-the-api-key#page-introduction). | YES      |                                                                                                                                                                                     |
-| `apiBaseUrl`       | [Checkout endpoint](https://docs.adyen.com/development-resources/live-endpoints#checkout-endpoints) of Adyen.                                            | NO       | `https://checkout-test.adyen.com/v68` (even though it is not required, you **need** to specify a URL for live environment)                                                          |
-| `legacyApiBaseUrl` | [Standard payment endpoint](https://docs.adyen.com/development-resources/live-endpoints#standard-payments-endpoints) of Adyen.                           | NO       | `https://pal-test.adyen.com/pal/servlet/Payment/v64` (even though it is not required, you **need** to specify a URL for live environment to use e.g. manualCapture, refund, cancel) |
+> Note that, multiple child attributes can be provided in the `adyen` and `commercetools` attribute group. Other configurations can be set as direct child attributes in `ADYEN_INTEGRATION_CONFIG`.
 
-> Note: Sometimes it's necessary to regenerate the `apiKey`, when you get `403 Forbidden error` from Adyen.
+#### Preparing the credentials
 
-### commercetools
+- Adyen credentials:
+  - For **test environment** follow the official Adyen [get started guide](https://docs.adyen.com/checkout/get-started) to set up your **test account**, get your API key.
+  - For **live environment** follow the official Adyen [documentation](https://docs.adyen.com/user-management/get-started-with-adyen#step-2-apply-for-your-live-account) for details.
+- commercetools project credentials:
+  - If you don't have the commercetools OAuth credentials,[create a commercetools API Client](https://docs.commercetools.com/getting-started.html#create-an-api-client).
+    - Note that, extension module requires `manage_payments, view_orders` [scopes](https://docs.commercetools.com/http-api-scopes) for the integration and `manage_types, manage_extensions` [scopes](https://docs.commercetools.com/http-api-scopes) for setting up required resources.
 
-If you don't have the commercetools OAuth credentials,[create a commercetools API Client](https://docs.commercetools.com/getting-started.html#create-an-api-client).
+### Required attributes
 
-> Note that, extension module requires `manage_payments, view_orders` [scopes](https://docs.commercetools.com/http-api-scopes) for the integration and `manage_types, manage_extensions` [scopes](https://docs.commercetools.com/http-api-scopes) for setting up required resources.
+| Group           | Name           | Content                                                                                                                                                        |
+| --------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `adyen`         | `apiKey`       | You'll be making API requests that are authenticated with an [Adyen API key](https://docs.adyen.com/user-management/how-to-get-the-api-key#page-introduction). |
+| `commercetools` | `clientId`     | OAuth 2.0 `client_id` and can be used to obtain a token.                                                                                                       |
+| `commercetools` | `clientSecret` | OAuth 2.0 `client_secret` and can be used to obtain a token.                                                                                                   |
 
-Multiple child attributes can be provided in the `commercetools` attribute. Each direct child attribute must represent 1 commercetools project like in the following example:
+### Optional attributes
 
-```
-{
-  "commercetools": {
-    "commercetoolsProjectKey1": { // commercetools project key of the first project
-      "clientId": "xxx",
-      "clientSecret": "xxx",
-      "apiUrl": "https://api.us-east-2.aws.commercetools.com/",
-      "authUrl": "https://auth.us-east-2.aws.commercetools.com/",
-      "authentication" : {
-        "scheme": "basic",
-        "username": "xxx",
-        "password": "xxx"
-      }
-    },
-    "commercetoolsProjectKey2": { // commercetools project key of the second project
-      "clientId": "xxx",
-      "clientSecret": "xxx"
-    }
-  }
-}
-```
-
-| Name             | Content                                                                                                                                                                                                                                                                                                                                                                                                      | Required | Default value                                     |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------------------------- |
-| `clientId`       | OAuth 2.0 `client_id` and can be used to obtain a token.                                                                                                                                                                                                                                                                                                                                                     | YES      |                                                   |
-| `clientSecret`   | OAuth 2.0 `client_secret` and can be used to obtain a token.                                                                                                                                                                                                                                                                                                                                                 | YES      |                                                   |
-| `apiUrl`         | The commercetools HTTP API is hosted at that URL.                                                                                                                                                                                                                                                                                                                                                            | NO       | `https://api.europe-west1.gcp.commercetools.com`  |
-| `authUrl`        | The commercetools’ OAuth 2.0 service is hosted at that URL.                                                                                                                                                                                                                                                                                                                                                  | NO       | `https://auth.europe-west1.gcp.commercetools.com` |
-| `authentication` | This setting only takes effect when `basicAuth` ( a child attribute in `ADYEN_INTEGRATION_CONFIG` ) is set to `true`. It enables authentication mechanism to prevent unauthorized access to the extension module. When it is provided as a JSON object, it must contain 3 separate attributes. They are `scheme` attribute which supports `basic` type, `username` and `password` attribute defined by user. | NO       |                                                   |
-
-### Other Configurations
-
-Other configurations can be set as direct child attributes in `ADYEN_INTEGRATION_CONFIG`.
-
-```
-{
-  "commercetools": {...},
-  "adyen": {...},
-  "adyenPaymentMethodsToNames": {
-    "klarna": {"en": "Klarna payment"},
-    "gpay": {"en": "Google Pay"},
-    "affirm": {"en": "Affirm"}
-  },
-  "logLevel": "DEBUG",
-  "port": 8080,
-  "keepAliveTimeout": 10000,
-  "basicAuth" : true,
-  "removeSensitiveData": false,
-  "addCommercetoolsLineItems": true
-}
-```
-
-| Name                         | Content                                                                                                                                                                                                                                                                                                                                                                                                                  | Required | Default value                                                                                                                |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `adyenPaymentMethodsToNames` | Key-value object where key is `paymentMethod.type` in makePayment Adyen request and value is the custom localized name that will be saved in CTP `payment.paymentMethodInfo.name`.                                                                                                                                                                                                                                       | NO       | `{scheme: {en: 'Credit Card'}, pp: {en: 'PayPal'}, klarna: {en: 'Klarna'}, gpay: {en: 'Google Pay'}, affirm: {en: 'Affirm'}` |
-| `port`                       | The port number on which the application will run.                                                                                                                                                                                                                                                                                                                                                                       | NO       | 8080                                                                                                                         |
-| `logLevel`                   | The log level (`trace`, `debug`, `info`, `warn`, `error`, `fatal`).                                                                                                                                                                                                                                                                                                                                                      | NO       | `info`                                                                                                                       |
-| `keepAliveTimeout`           | Milliseconds to keep a socket alive after the last response ([Node.js docs](https://nodejs.org/dist/latest/docs/api/http.html#http_server_keepalivetimeout)).                                                                                                                                                                                                                                                            | NO       | Node.js default (5 seconds)                                                                                                  |
-| `basicAuth`                  | Boolean attribute to enable/disable basic authentication to prevent unauthorized 3rd-party from accessing extension endpoint                                                                                                                                                                                                                                                                                             | NO       | false                                                                                                                        |
-| `removeSensitiveData`        | Boolean attribute. When set to "false", Adyen fields with additional information about the payment will be saved in the interface interaction and in the custom fields.                                                                                                                                                                                                                                                  | NO       | true                                                                                                                         |
-| `addCommercetoolsLineItems`  | Boolean attribute. If set to **true**, integration will add lineItems to payment methods that require lineItems on `makePaymentRequest`. Payment method types that requires [lineItems](https://docs.adyen.com/api-explorer/#/CheckoutService/latest/payments__reqParam_lineItems): `klarna`, `affirm`, `afterpay`, `afterpaytouch`, `klarna`, `ratepay`, `facilypay`, `clearpay`, `grabpay`, `paybright`, `pix`, `zip`. | NO       | false                                                                                                                        |
+| Group           | Name                         | Content                                                                                                                                                                                                                                                                                                                                                                                                                  | Default value                                                                                                                                                                           |
+| --------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `adyen`         | `apiBaseUrl`                 | [Checkout endpoint](https://docs.adyen.com/development-resources/live-endpoints#checkout-endpoints) of Adyen.                                                                                                                                                                                                                                                                                                            | `https://checkout-test.adyen.com/v68` (even though it is not required, you **need** to specify a URL for **live environment**)                                                          |
+| `adyen`         | `legacyApiBaseUrl`           | [Standard payment endpoint](https://docs.adyen.com/development-resources/live-endpoints#standard-payments-endpoints) of Adyen.                                                                                                                                                                                                                                                                                           | `https://pal-test.adyen.com/pal/servlet/Payment/v64` (even though it is not required, you **need** to specify a URL for **live environment** to use e.g. manualCapture, refund, cancel) |
+| `commercetools` | `apiUrl`                     | The commercetools HTTP API is hosted at that URL.                                                                                                                                                                                                                                                                                                                                                                        | `https://api.europe-west1.gcp.commercetools.com`                                                                                                                                        |
+| `commercetools` | `authUrl`                    | The commercetools’ OAuth 2.0 service is hosted at that URL.                                                                                                                                                                                                                                                                                                                                                              | `https://auth.europe-west1.gcp.commercetools.com`                                                                                                                                       |
+| `commercetools` | `authentication`             | This setting only takes effect when `basicAuth` ( a child attribute in `ADYEN_INTEGRATION_CONFIG` ) is set to `true`. It enables authentication mechanism to prevent unauthorized access to the extension module. When it is provided as a JSON object, it must contain 3 separate attributes. They are `scheme` attribute which supports `basic` type, `username` and `password` attribute defined by user.             |                                                                                                                                                                                         |
+| `other`         | `basicAuth`                  | Boolean attribute to enable/disable basic authentication to prevent unauthorized 3rd-party from accessing extension endpoint                                                                                                                                                                                                                                                                                             | false                                                                                                                                                                                   |
+| `other`         | `adyenPaymentMethodsToNames` | Key-value object where key is `paymentMethod.type` in makePayment Adyen request and value is the custom localized name that will be saved in CTP `payment.paymentMethodInfo.name`.                                                                                                                                                                                                                                       | `{scheme: {en: 'Credit Card'}, pp: {en: 'PayPal'}, klarna: {en: 'Klarna'}, gpay: {en: 'Google Pay'}, affirm: {en: 'Affirm'}`                                                            |
+| `other`         | `removeSensitiveData`        | Boolean attribute. When set to "false", Adyen fields with additional information about the payment will be saved in the interface interaction and in the custom fields.                                                                                                                                                                                                                                                  | true                                                                                                                                                                                    |
+| `other`         | `addCommercetoolsLineItems`  | Boolean attribute. If set to **true**, integration will add lineItems to payment methods that require lineItems on `makePaymentRequest`. Payment method types that requires [lineItems](https://docs.adyen.com/api-explorer/#/CheckoutService/latest/payments__reqParam_lineItems): `klarna`, `affirm`, `afterpay`, `afterpaytouch`, `klarna`, `ratepay`, `facilypay`, `clearpay`, `grabpay`, `paybright`, `pix`, `zip`. | false                                                                                                                                                                                   |
+| `other`         | `port`                       | The port number on which the application will run.                                                                                                                                                                                                                                                                                                                                                                       | 8080                                                                                                                                                                                    |
+| `other`         | `logLevel`                   | The log level (`trace`, `debug`, `info`, `warn`, `error`, `fatal`).                                                                                                                                                                                                                                                                                                                                                      | `info`                                                                                                                                                                                  |
+| `other`         | `keepAliveTimeout`           | Milliseconds to keep a socket alive after the last response ([Node.js docs](https://nodejs.org/dist/latest/docs/api/http.html#http_server_keepalivetimeout)).                                                                                                                                                                                                                                                            | Node.js default (5 seconds)                                                                                                                                                             |
 
 ### External file configuration
 

--- a/extension/test/e2e/fixtures/klarna-make-payment-form.html
+++ b/extension/test/e2e/fixtures/klarna-make-payment-form.html
@@ -206,9 +206,9 @@ Make payment request will come here</textarea
           makePaymentRequest.returnUrl = window.location.origin + '/return-url'
           makePaymentRequest.shopperLocale = 'de-DE'
           makePaymentRequest.countryCode = 'DE'
-          makePaymentRequest.shopperEmail = 'test@test.com'
+          makePaymentRequest.shopperEmail = 'customer@email.de'
           makePaymentRequest.dateOfBirth = '1977-01-30'
-          makePaymentRequest.telephoneNumber = '+491725554479'
+          makePaymentRequest.telephoneNumber = '+4917614287462'
           makePaymentRequest.shopperReference = 'YOUR TEST REFERENCE'
           makePaymentRequest.returnUrl = window.location.origin + '/return-url'
           makePaymentRequest.shopperName = {

--- a/extension/test/e2e/pageObjects/KlarnaPage.js
+++ b/extension/test/e2e/pageObjects/KlarnaPage.js
@@ -9,6 +9,22 @@ module.exports = class KlarnaPage {
       .frames()
       .find((f) => f.name() === 'klarna-hpp-instance-main')
     await klarnaMainFrame.waitForSelector('#scheme-payment-selector')
-    return this.page.click('#buy-button')
+    await this.page.click('#buy-button')
+
+    await this.processOtpAndPay()
+  }
+
+  async processOtpAndPay() {
+    const klarnaIframe = this.page
+      .frames()
+      .find((f) => f.name() === 'klarna-hpp-instance-fullscreen')
+    await klarnaIframe.waitForSelector('#onContinue')
+    await klarnaIframe.click('#onContinue')
+
+    await klarnaIframe.waitForSelector('#otp_field')
+    await klarnaIframe.type('#otp_field', '123456')
+
+    await klarnaIframe.waitForSelector('#mandate-review__confirmation-button')
+    await klarnaIframe.click('#mandate-review__confirmation-button')
   }
 }

--- a/notification/docs/HowToRun.md
+++ b/notification/docs/HowToRun.md
@@ -47,13 +47,13 @@ is `ADYEN_INTEGRATION_CONFIG` and it must contain settings as attributes in a JS
 }
 ```
 
-> Note that, multiple child attributes can be provided in the `adyen` and `commercetools` attribute group. Other configurations can be set as direct child attributes in `ADYEN_INTEGRATION_CONFIG`.
+> Note that multiple child attributes can be provided in the `adyen` and `commercetools` attribute group. Other configurations can be set as direct child attributes in `ADYEN_INTEGRATION_CONFIG`.
 
 #### Preparing the credentials
 
 - commercetools project credentials:
   - If you don't have the commercetools OAuth credentials,[create a commercetools API Client](https://docs.commercetools.com/getting-started.html#create-an-api-client).
-    - Note that, extension module requires `manage_payments` [scopes](https://docs.commercetools.com/http-api-scopes) for the integration and `manage_types` [scopes](https://docs.commercetools.com/http-api-scopes) for setting up required resources.
+    - Note that extension module requires `manage_payments` [scopes](https://docs.commercetools.com/http-api-scopes) for the integration and `manage_types` [scopes](https://docs.commercetools.com/http-api-scopes) for setting up required resources.
 
 ### Required attributes
 

--- a/notification/docs/HowToRun.md
+++ b/notification/docs/HowToRun.md
@@ -4,8 +4,9 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Environment variable](#environment-variable)
-  - [Adyen](#adyen)
-  - [commercetools](#commercetools)
+  - [Preparing the credentials](#preparing-the-credentials)
+  - [Required attributes](#required-attributes)
+  - [Optional attributes](#optional-attributes)
   - [Other Configurations](#other-configurations)
   - [External file configuration](#external-file-configuration)
 - [Commercetools project requirements](#commercetools-project-requirements)
@@ -42,76 +43,38 @@ is `ADYEN_INTEGRATION_CONFIG` and it must contain settings as attributes in a JS
       "secretHmacKey": "secretKey"
     }
   },
-  "getAdyenPaymentMethodsToNames": {
-    "visa": {"en": "Credit card visa"},
-    "gpay": {"en": "Google Pay"}
-  },
-  "logLevel": "DEBUG",
-  "port": "8081",
-  "keepAliveTimeout": 10000,
-  "removeSensitiveData": false
+  "port": 8081
 }
 ```
 
-The JSON structure will be described in detail in the next sections of this documentation.
+> Note that, multiple child attributes can be provided in the `adyen` and `commercetools` attribute group. Other configurations can be set as direct child attributes in `ADYEN_INTEGRATION_CONFIG`.
 
-### Adyen
+#### Preparing the credentials
 
-Multiple child attributes can be provided in the `adyen` attribute. Each direct child attribute must represent 1 adyen
-merchant account like in the following example:
+- commercetools project credentials:
+  - If you don't have the commercetools OAuth credentials,[create a commercetools API Client](https://docs.commercetools.com/getting-started.html#create-an-api-client).
+    - Note that, extension module requires `manage_payments` [scopes](https://docs.commercetools.com/http-api-scopes) for the integration and `manage_types` [scopes](https://docs.commercetools.com/http-api-scopes) for setting up required resources.
 
-```
-{
-  "adyen": {
-    "adyenMerchantAccount1": {
-      "enableHmacSignature": "false"
-    },
-    "adyenMerchantAccount2": {
-      "enableHmacSignature": "true",
-      "secretHmacKey": "secretKey"
-    }
-  }
-}
-```
+### Required attributes
 
-| Name                  | Content                                                                                                                                            | Required | Default value |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------- |
-| `enableHmacSignature` | Verify the integrity of notifications using [Adyen HMAC signatures](https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures). | NO       | `true`        |
-| `secretHmacKey`       | The generated secret HMAC key that is linked to a Adyen **Standard Notification** endpoint                                                         | NO       |               |
+| Group           | Name           | Content                                                      |
+| --------------- | -------------- | ------------------------------------------------------------ |
+| `commercetools` | `clientId`     | OAuth 2.0 `client_id` and can be used to obtain a token.     |
+| `commercetools` | `clientSecret` | OAuth 2.0 `client_secret` and can be used to obtain a token. |
 
-### commercetools
+### Optional attributes
 
-If you don't have the commercetools OAuth
-credentials,[create a commercetools API Client](https://docs.commercetools.com/getting-started.html#create-an-api-client)
-.
-
-> Note that, notification module requires `manage_payments` [scope](https://docs.commercetools.com/http-api-scopes) for the integration and `manage_types` [scope](https://docs.commercetools.com/http-api-scopes) for setting up required resources.
-
-Multiple child attributes can be provided in the `commercetools` attribute. Each direct child attribute must represent 1 commercetools project like in the following example:
-
-```
-{
-  "commercetools": {
-    "commercetoolsProjectKey1": {
-      "clientId": "xxx",
-      "clientSecret": "xxx"
-    },
-    "commercetoolsProjectKey2": {
-      "clientId": "xxx",
-      "clientSecret": "xxx"
-      "apiUrl": "https://api.us-east-2.aws.commercetools.com/"
-      "authUrl": "https://auth.us-east-2.aws.commercetools.com/"
-    }
-  }
-}
-```
-
-| Name           | Content                                                      | Required | Default value                                     |
-| -------------- | ------------------------------------------------------------ | -------- | ------------------------------------------------- |
-| `clientId`     | OAuth 2.0 `client_id` and can be used to obtain a token.     | YES      |                                                   |
-| `clientSecret` | OAuth 2.0 `client_secret` and can be used to obtain a token. | YES      |                                                   |
-| `apiUrl`       | The commercetools HTTP API is hosted at that URL.            | NO       | `https://api.europe-west1.gcp.commercetools.com`  |
-| `authUrl`      | The commercetools’ OAuth 2.0 service is hosted at that URL.  | NO       | `https://auth.europe-west1.gcp.commercetools.com` |
+| Group           | Name                         | Content                                                                                                                                                                         | Default value                                                                                         |
+| --------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `adyen`         | `enableHmacSignature`        | Verify the integrity of notifications using [Adyen HMAC signatures](https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures).                              | true                                                                                                  |
+| `adyen`         | `secretHmacKey`              | The generated secret HMAC key that is linked to a Adyen **Standard Notification** endpoint                                                                                      |                                                                                                       |
+| `commercetools` | `apiUrl`                     | The commercetools HTTP API is hosted at that URL.                                                                                                                               | `https://api.europe-west1.gcp.commercetools.com`                                                      |
+| `commercetools` | `authUrl`                    | The commercetools’ OAuth 2.0 service is hosted at that URL.                                                                                                                     | `https://auth.europe-west1.gcp.commercetools.com`                                                     |
+| `other`         | `adyenPaymentMethodsToNames` | Key-value object where key is `paymentMethod` returned in the notification and value is the custom localized name that will be saved in CTP `payment.paymentMethodInfo.method`. | `{scheme: {en: 'Credit Card'}, pp: {en: 'PayPal'}, klarna: {en: 'Klarna'}, gpay: {en: 'Google Pay'}}` |
+| `other`         | `removeSensitiveData`        | Boolean attribute. When set to "false", Adyen fields with additional information about the payment will be saved in the interface interaction and in the custom fields.         | true                                                                                                  |
+| `other`         | `port`                       | The port number on which the application will run.                                                                                                                              | 443                                                                                                   |
+| `other`         | `logLevel`                   | The log level (`trace`, `debug`, `info`, `warn`, `error`, `fatal`).                                                                                                             | `info`                                                                                                |
+| `other`         | `keepAliveTimeout`           | Milliseconds to keep a socket alive after the last response ([Node.js docs](https://nodejs.org/dist/latest/docs/api/http.html#http_server_keepalivetimeout)).                   | Node.js default (5 seconds)                                                                           |
 
 ### Other Configurations
 

--- a/notification/docs/HowToRun.md
+++ b/notification/docs/HowToRun.md
@@ -47,7 +47,11 @@ is `ADYEN_INTEGRATION_CONFIG` and it must contain settings as attributes in a JS
 }
 ```
 
-> Note that multiple child attributes can be provided in the `adyen` and `commercetools` attribute group. Other configurations can be set as direct child attributes in `ADYEN_INTEGRATION_CONFIG`.
+`ADYEN_INTEGRATION_CONFIG` JSON structure contains different `attribute groups` as described below:
+
+- `adyen` attribute group: Multiple child attributes can be provided in the `adyen` attribute. Each direct child attribute must represent an adyen merchant account.
+- `commercetools` attribute group: Multiple child attributes can be provided in the `commercetools` attribute. Each direct child attribute must represent a commercetools project.
+- `other` attribute group: Attributes in this group can be set as direct child attributes in `the root of the JSON`.
 
 #### Preparing the credentials
 


### PR DESCRIPTION
On one of the review: https://github.com/commercetools/commercetools-adyen-integration/pull/918#discussion_r808983409 we had a discussion and found out the existing documentation creates confusion, as it's grouped in a way that you can not understand what is the required values and optional ones, also the given examples with the values are defined with the not default values as it's better to suggest to use default values as it might be the better choice: https://github.com/commercetools/commercetools-adyen-integration/pull/918#discussion_r808985460