### PR TITLE
fix klarna e2e test.

### DIFF
--- a/extension/test/e2e/fixtures/klarna-make-payment-form.html
+++ b/extension/test/e2e/fixtures/klarna-make-payment-form.html
@@ -206,9 +206,9 @@ Make payment request will come here</textarea
           makePaymentRequest.returnUrl = window.location.origin + '/return-url'
           makePaymentRequest.shopperLocale = 'de-DE'
           makePaymentRequest.countryCode = 'DE'
-          makePaymentRequest.shopperEmail = 'test@test.com'
+          makePaymentRequest.shopperEmail = 'customer@email.de'
           makePaymentRequest.dateOfBirth = '1977-01-30'
-          makePaymentRequest.telephoneNumber = '+491725554479'
+          makePaymentRequest.telephoneNumber = '+4917614287462'
           makePaymentRequest.shopperReference = 'YOUR TEST REFERENCE'
           makePaymentRequest.returnUrl = window.location.origin + '/return-url'
           makePaymentRequest.shopperName = {

--- a/extension/test/e2e/pageObjects/KlarnaPage.js
+++ b/extension/test/e2e/pageObjects/KlarnaPage.js
@@ -11,7 +11,7 @@ module.exports = class KlarnaPage {
     await klarnaMainFrame.waitForSelector('#scheme-payment-selector')
     await this.page.click('#buy-button')
 
-    return await this.processOtpAndPay()
+    await this.processOtpAndPay()
   }
 
   async processOtpAndPay() {

--- a/extension/test/e2e/pageObjects/KlarnaPage.js
+++ b/extension/test/e2e/pageObjects/KlarnaPage.js
@@ -9,6 +9,22 @@ module.exports = class KlarnaPage {
       .frames()
       .find((f) => f.name() === 'klarna-hpp-instance-main')
     await klarnaMainFrame.waitForSelector('#scheme-payment-selector')
-    return this.page.click('#buy-button')
+    await this.page.click('#buy-button')
+
+    return await this.processOtpAndPay()
+  }
+
+  async processOtpAndPay() {
+    const klarnaIframe = this.page
+      .frames()
+      .find((f) => f.name() === 'klarna-hpp-instance-fullscreen')
+    await klarnaIframe.waitForSelector('#onContinue')
+    await klarnaIframe.click('#onContinue')
+
+    await klarnaIframe.waitForSelector('#otp_field')
+    await klarnaIframe.type('#otp_field', '123456')
+
+    await klarnaIframe.waitForSelector('#mandate-review__confirmation-button')
+    await klarnaIframe.click('#mandate-review__confirmation-button')
   }
 }


### PR DESCRIPTION
klarna test were not working, it seems now klarna requires a otp step, which I added to test, used the test accounts documented by klarna: https://docs.klarna.com/resources/test-environment/sample-data/#germany, old ones were not working 🤷🏽 