### PR TITLE
Update notification to parse aws url correctly

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commercetools-adyen-integration-extension",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "commercetools-adyen-integration-extension",
-      "version": "9.7.0",
+      "version": "9.8.0",
       "license": "MIT",
       "dependencies": {
         "@commercetools/api-request-builder": "5.6.3",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commercetools-adyen-integration-extension",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Integration between commercetools and Adyen payment service provider",
   "license": "MIT",
   "scripts": {

--- a/extension/test/unit/google-function.spec.js
+++ b/extension/test/unit/google-function.spec.js
@@ -18,6 +18,7 @@ describe('Google cloud function', () => {
     body: {
       resource: { obj: {} },
     },
+    url: ''
   }
 
   const mockResponse = {

--- a/extension/test/unit/google-function.spec.js
+++ b/extension/test/unit/google-function.spec.js
@@ -18,7 +18,7 @@ describe('Google cloud function', () => {
     body: {
       resource: { obj: {} },
     },
-    url: ''
+    url: '',
   }
 
   const mockResponse = {

--- a/notification/index.googleFunction.js
+++ b/notification/index.googleFunction.js
@@ -1,3 +1,4 @@
+const url = require('url')
 const handler = require('./src/handler/notification/notification.handler')
 const logger = require('./src/utils/logger').getLogger()
 const { getNotificationForTracking } = require('./src/utils/commons')
@@ -12,7 +13,8 @@ exports.notificationTrigger = async (request, response) => {
   }
   try {
     for (const notification of notificationItems) {
-      const ctpProjectConfig = getCtpProjectConfig(notification, request)
+      const parts = url.parse(request.url)
+      const ctpProjectConfig = getCtpProjectConfig(notification, parts.path)
       const adyenConfig = getAdyenConfig(notification)
 
       await handler.processNotification(

--- a/notification/index.lambda.js
+++ b/notification/index.lambda.js
@@ -21,7 +21,7 @@ exports.handler = async (event) => {
   }
   try {
     for (const notification of notificationItems) {
-      const ctpProjectConfig = getCtpProjectConfig(notification)
+      const ctpProjectConfig = getCtpProjectConfig(notification, event.path)
       const adyenConfig = getAdyenConfig(notification)
 
       await handler.processNotification(

--- a/notification/package-lock.json
+++ b/notification/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commercetools-adyen-integration-notification",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "commercetools-adyen-integration-notification",
-      "version": "9.7.0",
+      "version": "9.8.0",
       "dependencies": {
         "@adyen/api-library": "10.3.0",
         "@commercetools/api-request-builder": "5.6.3",

--- a/notification/package.json
+++ b/notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commercetools-adyen-integration-notification",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Part of the integration of Adyen with commercetools responsible to receive and process notifications from Adyen",
   "scripts": {
     "check-coverage": "nyc check-coverage --lines 83",

--- a/notification/src/api/notification/notification.controller.js
+++ b/notification/src/api/notification/notification.controller.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const url = require('url')
 const httpUtils = require('../../utils/commons')
 const { isRecoverableError, getErrorCause } = require('../../utils/error-utils')
 
@@ -21,7 +22,8 @@ async function handleNotification(request, response) {
     const notifications = _.get(JSON.parse(body), 'notificationItems', [])
     for (const notification of notifications) {
       logger.debug('Received notification', JSON.stringify(notification))
-      const ctpProjectConfig = getCtpProjectConfig(notification, request)
+      const parts = url.parse(request.url)
+      const ctpProjectConfig = getCtpProjectConfig(notification, parts.path)
       const adyenConfig = getAdyenConfig(notification)
 
       await processNotification(

--- a/notification/src/server.js
+++ b/notification/src/server.js
@@ -4,10 +4,14 @@ const utils = require('./utils/commons')
 const { routes: defaultRoutes } = require('./routes')
 const logger = require('./utils/logger').getLogger()
 
+function getHandlerNameFromUrl(parts) {
+  return parts.path?.split('/')?.slice(-2)?.[0] ?? ''
+}
+
 function setupServer(routes = defaultRoutes) {
   return http.createServer(async (request, response) => {
     const parts = url.parse(request.url)
-    const path = parts.path?.split('/')?.slice(-2)?.[0] ?? ''
+    const path = getHandlerNameFromUrl(parts)
     const route = routes[`/${path}`]
     if (route)
       try {

--- a/notification/src/utils/parser.js
+++ b/notification/src/utils/parser.js
@@ -1,15 +1,13 @@
-const url = require('url')
 const _ = require('lodash')
 const config = require('../config/config')
 
-function getCtpProjectConfig(notification, request) {
+function getCtpProjectConfig(notification, path) {
   let commercetoolsProjectKey =
     notification?.NotificationRequestItem?.additionalData?.[
       `metadata.ctProjectKey`
     ]
-  if (!commercetoolsProjectKey && request) {
-    const parts = url.parse(request.url)
-    commercetoolsProjectKey = parts.path?.split('/')?.slice(-1)?.[0]
+  if (!commercetoolsProjectKey && path) {
+    commercetoolsProjectKey = path.split('/')?.slice(-1)?.[0]
   }
 
   if (_.isEmpty(commercetoolsProjectKey)) {

--- a/notification/test/unit/google-function.spec.js
+++ b/notification/test/unit/google-function.spec.js
@@ -29,6 +29,7 @@ describe('Google Function handler', () => {
         },
       ],
     },
+    url: '',
   }
 
   const mockResponse = {

--- a/notification/test/unit/notification.controller.spec.js
+++ b/notification/test/unit/notification.controller.spec.js
@@ -101,6 +101,7 @@ describe('notification controller', () => {
     // prepare:
     const requestMock = {
       method: 'POST',
+      url: '/',
     }
     const responseMock = {
       writeHead: () => {},
@@ -147,6 +148,7 @@ describe('notification controller', () => {
     // prepare:
     const requestMock = {
       method: 'POST',
+      url: '/',
     }
     const responseMock = {
       writeHead: () => {},
@@ -188,6 +190,7 @@ describe('notification controller', () => {
       // prepare:
       const requestMock = {
         method: 'POST',
+        url: '/',
       }
       const responseMock = {
         writeHead: () => {},


### PR DESCRIPTION
According to these docs: https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html, https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html I found out a way how to get the correct URL in AWS. However it's not tested yet in AWS.