### PR TITLE
Update getting URL path for AWS

### DIFF
--- a/extension/test/e2e/pageObjects/KlarnaPage.js
+++ b/extension/test/e2e/pageObjects/KlarnaPage.js
@@ -25,7 +25,9 @@ export default class KlarnaPage {
     await klarnaIframe.waitForSelector('#otp_field')
     await klarnaIframe.type('#otp_field', '123456')
 
-    await klarnaIframe.waitForSelector('#mandate-review__confirmation-button')
-    await klarnaIframe.click('#mandate-review__confirmation-button')
+    await klarnaIframe.waitForSelector(
+      '#invoice_kp-purchase-review-continue-button'
+    )
+    await klarnaIframe.click('#invoice_kp-purchase-review-continue-button')
   }
 }

--- a/notification/index.lambda.js
+++ b/notification/index.lambda.js
@@ -1,4 +1,3 @@
-const util = require('util')
 const handler = require('./src/handler/notification/notification.handler')
 const logger = require('./src/utils/logger').getLogger()
 const { getNotificationForTracking } = require('./src/utils/commons')
@@ -22,8 +21,6 @@ exports.handler = async (event) => {
   }
   try {
     for (const notification of notificationItems) {
-      console.log('event is ' + util.inspect(event, { depth: null }))
-      console.log('event path is ' + JSON.stringify(event.rawPath))
       const ctpProjectConfig = getCtpProjectConfig(notification, event.rawPath)
       const adyenConfig = getAdyenConfig(notification)
 

--- a/notification/index.lambda.js
+++ b/notification/index.lambda.js
@@ -22,9 +22,9 @@ exports.handler = async (event) => {
   }
   try {
     for (const notification of notificationItems) {
-      console.log('event is ' + util.inspect(event, {depth: null}))
-      console.log('event path is ' + JSON.stringify(event.path))
-      const ctpProjectConfig = getCtpProjectConfig(notification, event.path)
+      console.log('event is ' + util.inspect(event, { depth: null }))
+      console.log('event path is ' + JSON.stringify(event.rawPath))
+      const ctpProjectConfig = getCtpProjectConfig(notification, event.rawPath)
       const adyenConfig = getAdyenConfig(notification)
 
       await handler.processNotification(

--- a/notification/index.lambda.js
+++ b/notification/index.lambda.js
@@ -1,3 +1,4 @@
+const util = require('util')
 const handler = require('./src/handler/notification/notification.handler')
 const logger = require('./src/utils/logger').getLogger()
 const { getNotificationForTracking } = require('./src/utils/commons')
@@ -21,6 +22,8 @@ exports.handler = async (event) => {
   }
   try {
     for (const notification of notificationItems) {
+      console.log('event is ' + util.inspect(event, {depth: null}))
+      console.log('event path is ' + JSON.stringify(event.path))
       const ctpProjectConfig = getCtpProjectConfig(notification, event.path)
       const adyenConfig = getAdyenConfig(notification)
 

--- a/notification/src/utils/parser.js
+++ b/notification/src/utils/parser.js
@@ -2,6 +2,7 @@ const _ = require('lodash')
 const config = require('../config/config')
 
 function getCtpProjectConfig(notification, path) {
+  console.log(`path is ${JSON.stringify(path)}`)
   let commercetoolsProjectKey =
     notification?.NotificationRequestItem?.additionalData?.[
       `metadata.ctProjectKey`
@@ -9,6 +10,7 @@ function getCtpProjectConfig(notification, path) {
   if (!commercetoolsProjectKey && path) {
     commercetoolsProjectKey = path.split('/')?.slice(-1)?.[0]
   }
+  console.log(`commercetoolsProjectKey is ${JSON.stringify(commercetoolsProjectKey)}`)
 
   if (_.isEmpty(commercetoolsProjectKey)) {
     throw new Error(

--- a/notification/src/utils/parser.js
+++ b/notification/src/utils/parser.js
@@ -2,7 +2,6 @@ const _ = require('lodash')
 const config = require('../config/config')
 
 function getCtpProjectConfig(notification, path) {
-  console.log(`path is ${JSON.stringify(path)}`)
   let commercetoolsProjectKey =
     notification?.NotificationRequestItem?.additionalData?.[
       `metadata.ctProjectKey`
@@ -10,7 +9,6 @@ function getCtpProjectConfig(notification, path) {
   if (!commercetoolsProjectKey && path) {
     commercetoolsProjectKey = path.split('/')?.slice(-1)?.[0]
   }
-  console.log(`commercetoolsProjectKey is ${JSON.stringify(commercetoolsProjectKey)}`)
 
   if (_.isEmpty(commercetoolsProjectKey)) {
     throw new Error(


### PR DESCRIPTION
In order to get the URL path for AWS, it is necessary to use `rawPath` attr as documented in the link below.

https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format

So I made this change in this PR.