### PR TITLE
Fix syntax issues in the init file.

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commercetools-adyen-integration-extension",
-  "version": "9.8.0",
+  "version": "9.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "commercetools-adyen-integration-extension",
-      "version": "9.8.0",
+      "version": "9.8.1",
       "license": "MIT",
       "dependencies": {
         "@commercetools/api-request-builder": "5.6.3",
@@ -21,6 +21,7 @@
         "lodash": "4.17.21",
         "node-fetch": "2.6.7",
         "rc": "1.2.8",
+        "run-func": "^3.0.0",
         "serialize-error": "8.1.0"
       },
       "devDependencies": {
@@ -6133,6 +6134,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/run-func": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-func/-/run-func-3.0.0.tgz",
+      "integrity": "sha512-RZwVzBrD7biV5CiAgwEUdaRGt0hLjBrhn4PqemBuNogH9Sc/8Bv8p+6F6AweU5bxZXsb3Mxltgu+/f+TGi0udA==",
+      "bin": {
+        "run-func": "index.js",
+        "run-func-mem": "mem.js"
+      },
+      "engines": {
+        "node": ">=10.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
     "node_modules/rxjs": {
       "version": "7.5.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.2.tgz",
@@ -11788,6 +11802,11 @@
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "run-func": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-func/-/run-func-3.0.0.tgz",
+      "integrity": "sha512-RZwVzBrD7biV5CiAgwEUdaRGt0hLjBrhn4PqemBuNogH9Sc/8Bv8p+6F6AweU5bxZXsb3Mxltgu+/f+TGi0udA=="
     },
     "rxjs": {
       "version": "7.5.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commercetools-adyen-integration-extension",
-  "version": "9.8.0",
+  "version": "9.8.1",
   "description": "Integration between commercetools and Adyen payment service provider",
   "license": "MIT",
   "type": "module",
@@ -20,7 +20,7 @@
     "format": "prettier --write .",
     "zip-google-function": "cp index.googleFunction.js index.js && zip -r extension-module.zip src resources .extensionrc index.js package.json && rm index.js",
     "zip-lambda-function": "cp index.lambda.js index.js && npm ci --production && zip -r extension-module.zip . && rm index.js",
-    "setup-resources": "node -e 'require(\"./src/setup.js\").setupExtensionResources()'"
+    "setup-resources": "run-func ./src/setup.js setupExtensionResources"
   },
   "keywords": [
     "Adyen",
@@ -77,6 +77,7 @@
     "lodash": "4.17.21",
     "node-fetch": "2.6.7",
     "rc": "1.2.8",
+    "run-func": "^3.0.0",
     "serialize-error": "8.1.0"
   },
   "mocha": {

--- a/extension/src/init.js
+++ b/extension/src/init.js
@@ -1,11 +1,14 @@
 import { setupServer } from './server.js'
-import logger from './utils.js'
+import utils from './utils.js'
 import config from './config/config.js'
 
 const port = config.getModuleConfig().port || 8080
 
+const server = setupServer()
+const logger = utils.getLogger()
+
 if (config.getModuleConfig().keepAliveTimeout !== undefined)
-  setupServer.keepAliveTimeout = config.getModuleConfig().keepAliveTimeout
-setupServer.listen(port, async () => {
+  server.keepAliveTimeout = config.getModuleConfig().keepAliveTimeout
+server.listen(port, async () => {
   logger.info(`Extension module is running at http://localhost:${port}`)
 })

--- a/notification/package-lock.json
+++ b/notification/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commercetools-adyen-integration-notification",
-  "version": "9.8.0",
+  "version": "9.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "commercetools-adyen-integration-notification",
-      "version": "9.8.0",
+      "version": "9.8.1",
       "dependencies": {
         "@adyen/api-library": "10.3.0",
         "@commercetools/api-request-builder": "5.6.3",
@@ -21,6 +21,7 @@
         "lodash": "4.17.21",
         "node-fetch": "2.6.7",
         "rc": "1.2.8",
+        "run-func": "^3.0.0",
         "serialize-error": "8.1.0",
         "verror": "1.10.1"
       },
@@ -4977,6 +4978,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/run-func": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-func/-/run-func-3.0.0.tgz",
+      "integrity": "sha512-RZwVzBrD7biV5CiAgwEUdaRGt0hLjBrhn4PqemBuNogH9Sc/8Bv8p+6F6AweU5bxZXsb3Mxltgu+/f+TGi0udA==",
+      "bin": {
+        "run-func": "index.js",
+        "run-func-mem": "mem.js"
+      },
+      "engines": {
+        "node": ">=10.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
     "node_modules/rxjs": {
       "version": "7.5.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.2.tgz",
@@ -9516,6 +9530,11 @@
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "run-func": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-func/-/run-func-3.0.0.tgz",
+      "integrity": "sha512-RZwVzBrD7biV5CiAgwEUdaRGt0hLjBrhn4PqemBuNogH9Sc/8Bv8p+6F6AweU5bxZXsb3Mxltgu+/f+TGi0udA=="
     },
     "rxjs": {
       "version": "7.5.2",

--- a/notification/package.json
+++ b/notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commercetools-adyen-integration-notification",
-  "version": "9.8.0",
+  "version": "9.8.1",
   "description": "Part of the integration of Adyen with commercetools responsible to receive and process notifications from Adyen",
   "type": "module",
   "scripts": {
@@ -18,7 +18,7 @@
     "rename-indexfile": "cp index.googleFunction.js index.js",
     "zip-google-function": "cp index.googleFunction.js index.js && zip -r notification-module.zip src resources .notificationrc index.js package.json && rm index.js",
     "zip-lambda-function": "cp index.lambda.js index.js && npm ci --production && zip -r notification-module.zip . && rm index.js",
-    "setup-resources": "node -e 'require(\"./src/setup.js\").setupNotificationResources()'"
+    "setup-resources": "run-func ./src/setup.js setupNotificationResources"
   },
   "keywords": [
     "adyen",
@@ -59,6 +59,7 @@
     "lodash": "4.17.21",
     "node-fetch": "2.6.7",
     "rc": "1.2.8",
+    "run-func": "^3.0.0",
     "serialize-error": "8.1.0",
     "verror": "1.10.1"
   },
@@ -72,12 +73,12 @@
     "husky": "8.0.1",
     "ip": "1.1.8",
     "lint-staged": "12.4.1",
+    "localtunnel": "2.0.2",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
     "p-map": "5.4.0",
     "prettier": "2.6.2",
-    "sinon": "14.0.0",
-    "localtunnel": "2.0.2"
+    "sinon": "14.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
1) We have an issue with the docker image in the latest release(Since Es module changes are merged into master).
Fix the issue in the init file.
 Issue: https://github.com/commercetools/commercetools-adyen-integration/issues/963

2) Setup-resources in [package.json](https://github.com/commercetools/commercetools-adyen-integration/pull/964/files#diff-0e96fc4c0e4b663545725cc50af120099cb873ea9e3f16eee74d074e39be13feL23) was using require to call setup.js file and that is no more supported. Hence I have added a new library `run-func` which runs the function from terminal instance.  

 Issue : https://github.com/commercetools/commercetools-adyen-integration/issues/965