### PR TITLE
Fix klarna test

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commercetools-adyen-integration-extension",
-  "version": "9.9.0",
+  "version": "9.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "commercetools-adyen-integration-extension",
-      "version": "9.9.0",
+      "version": "9.9.1",
       "license": "MIT",
       "dependencies": {
         "@commercetools/api-request-builder": "5.6.3",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commercetools-adyen-integration-extension",
-  "version": "9.9.0",
+  "version": "9.9.1",
   "description": "Integration between commercetools and Adyen payment service provider",
   "license": "MIT",
   "type": "module",

--- a/extension/test/e2e/pageObjects/KlarnaPage.js
+++ b/extension/test/e2e/pageObjects/KlarnaPage.js
@@ -18,7 +18,7 @@ export default class KlarnaPage {
     const klarnaIframe = this.page
       .frames()
       .find((f) => f.name() === 'klarna-hpp-instance-fullscreen')
-    await klarnaIframe.waitForSelector('#onContinue')
+    await klarnaIframe.waitForSelector('#onContinue', { visible: true })
     await klarnaIframe.click('#onContinue')
 
     await klarnaIframe.waitForSelector('#otp_field')

--- a/notification/package.json
+++ b/notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commercetools-adyen-integration-notification",
-  "version": "9.8.2",
+  "version": "9.9.1",
   "description": "Part of the integration of Adyen with commercetools responsible to receive and process notifications from Adyen",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Klarna e2e test suddenly stops working. It was not waiting for the modal window to display in the klarna payment page and it just immediately clicks the button. I found out that it's because we were not waiting for the button to be visible. I added the waiting for visibility option.

It is not clear why it was working before. I tried to downgrade to version 14, but the problem was still there. What I could notice is that it takes couple of seconds to load the modal window in Klarna. Maybe it's because now it takes more time to load the modal window than before when the modal window popped up immediately?