### PR TITLE
Improve error logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
   notification_build:
     name: Notification Module
     concurrency: notification_build
+    needs: extension_build
     runs-on: ubuntu-latest
     env:
       ADYEN_INTEGRATION_CONFIG: ${{ secrets.ADYEN_INTEGRATION_CONFIG }}

--- a/extension/src/utils.js
+++ b/extension/src/utils.js
@@ -38,7 +38,9 @@ function getLogger() {
 }
 
 function handleUnexpectedPaymentError(paymentObj, err) {
-  const errorMessage = `Unexpected error (Payment ID: ${paymentObj?.id}): ${err.message}.`
+  const errorMessage =
+    '[commercetools-adyen-integration-extension] ' +
+    `Unexpected error (Payment ID: ${paymentObj?.id}): ${err.message}.`
   const errorStackTrace = `Unexpected error (Payment ID: ${
     paymentObj?.id
   }): ${JSON.stringify(serializeError(err))}`

--- a/extension/test/unit/payment.controller.spec.js
+++ b/extension/test/unit/payment.controller.spec.js
@@ -134,6 +134,10 @@ describe('Payment controller', () => {
       expect(data.errors).to.not.empty
       expect(data.errors).to.have.lengthOf(1)
       expect(data.errors[0].code).to.equal('General')
+      expect(data.errors[0].message).to.equal(
+        '[commercetools-adyen-integration-extension] ' +
+          'Unexpected error (Payment ID: undefined): request.on is not a function.'
+      )
     }
 
     sinon.stub(utils, 'sendResponse').callsFake(sendResponse)


### PR DESCRIPTION
I added name of the module (extension) to make the error clear that it comes from the extension module.

Boy-scout change: I also put back the dependency between build of extension and notification modules. Now the notification module will wait for build from the extension module to complete before it starts. To be frank the 2 modules do not depend on each other, but I see that the builds are failing randomly, so maybe that could be a problem. Let's see if it helps.