### PR TITLE
#930 add idempotency key field

### DIFF
--- a/docs/adr/0008-idempotency-key.md
+++ b/docs/adr/0008-idempotency-key.md
@@ -4,7 +4,7 @@ Date: 2022-08-17
 
 ## Status
 
-Approved (https://github.com/commercetools/commercetools-adyen-integration/pull/1000)
+[Approved](https://github.com/commercetools/commercetools-adyen-integration/pull/1000)
 
 ## Context
 Payment modifications actions are using POST requests. POST is not idempotent by definition. Therefore, by default it is not possible to retry when payment modification requests fail if you want to avoid unwanted duplications. For example, when partial capture gets a timeout error from Adyen, it could cause double-processing of the same request when retry as Adyen will consider the retry request as a new partial capture request.

--- a/docs/adr/0008-idempotency-key.md
+++ b/docs/adr/0008-idempotency-key.md
@@ -4,7 +4,7 @@ Date: 2022-08-17
 
 ## Status
 
-Approved
+Approved (https://github.com/commercetools/commercetools-adyen-integration/pull/1000)
 
 ## Context
 Payment modifications actions are using POST requests. POST is not idempotent by definition. Therefore, by default it is not possible to retry when payment modification requests fail if you want to avoid unwanted duplications. For example, when partial capture gets a timeout error from Adyen, it could cause double-processing of the same request when retry as Adyen will consider the retry request as a new partial capture request.

--- a/docs/adr/0008-idempotency-key.md
+++ b/docs/adr/0008-idempotency-key.md
@@ -1,4 +1,4 @@
-# 7. Idempotency key
+# 8. Idempotency key
 
 Date: 2022-08-17
 

--- a/docs/adr/0008-idempotency-key.md
+++ b/docs/adr/0008-idempotency-key.md
@@ -1,0 +1,20 @@
+# 7. Idempotency key
+
+Date: 2022-08-17
+
+## Status
+
+Approved
+
+## Context
+Payment modifications actions are using POST requests. POST is not idempotent by definition. Therefore, by default it is not possible to retry when payment modification requests fail if you want to avoid unwanted duplications. For example, when partial capture gets a timeout error from Adyen, it could cause double-processing of the same request when retry as Adyen will consider the retry request as a new partial capture request.
+
+To enable retry on failure for payment modifications, an idempotency key needs to be sent with every request. This idempotency key is sent in the header as `Idempotency-Key:<key>`. It has to be unique per request so that we can retry the request with the same idempotency key.
+
+There are 2 payment modification actions currently supported in Adyen-integration and that could be affected by the idempotency problem: [partial capture](../../extension/docs/ManualCapture.md) and [partial refund](../../extension/docs/Refund.md). Both payment modifications are triggered by adding a payment transaction.   
+
+## Decision
+A new String custom field called `idempotencyKey` will be added to the payment transaction. When this field is present, Adyen-integration will take its value and send it as as a value for `Idempotency-Key` header. 
+
+## Source
+https://docs.adyen.com/development-resources/api-idempotency

--- a/docs/adr/0008-idempotency-key.md
+++ b/docs/adr/0008-idempotency-key.md
@@ -14,7 +14,7 @@ To enable retry on failure for payment modifications, an idempotency key needs t
 There are 2 payment modification actions currently supported in Adyen-integration and that could be affected by the idempotency problem: [partial capture](../../extension/docs/ManualCapture.md) and [partial refund](../../extension/docs/Refund.md). Both payment modifications are triggered by adding a payment transaction.   
 
 ## Decision
-A new String custom field called `idempotencyKey` will be added to the payment transaction. When this field is present, Adyen-integration will take its value and send it as a value for `Idempotency-Key` header. 
+A new String custom field called `idempotencyKey` will be added to the payment transaction custom type `key="ctp-adyen-integration-transaction-payment-type"`. When this field `idempotencyKey` is present in the payment transaction, Adyen-integration will take its value and send it as a value for `Idempotency-Key` header. 
 
 ## Source
 https://docs.adyen.com/development-resources/api-idempotency

--- a/docs/adr/0008-idempotency-key.md
+++ b/docs/adr/0008-idempotency-key.md
@@ -14,7 +14,7 @@ To enable retry on failure for payment modifications, an idempotency key needs t
 There are 2 payment modification actions currently supported in Adyen-integration and that could be affected by the idempotency problem: [partial capture](../../extension/docs/ManualCapture.md) and [partial refund](../../extension/docs/Refund.md). Both payment modifications are triggered by adding a payment transaction.   
 
 ## Decision
-A new String custom field called `idempotencyKey` will be added to the payment transaction. When this field is present, Adyen-integration will take its value and send it as as a value for `Idempotency-Key` header. 
+A new String custom field called `idempotencyKey` will be added to the payment transaction. When this field is present, Adyen-integration will take its value and send it as a value for `Idempotency-Key` header. 
 
 ## Source
 https://docs.adyen.com/development-resources/api-idempotency

--- a/extension/.prettierignore
+++ b/extension/.prettierignore
@@ -6,3 +6,4 @@ package-lock.json
 .prettierignore
 .eslintrc
 .nyc_output
+.prettierrc.json

--- a/extension/.prettierignore
+++ b/extension/.prettierignore
@@ -5,5 +5,4 @@ package.json
 package-lock.json
 .prettierignore
 .eslintrc
-.nyc_output
 .prettierrc.json

--- a/extension/.prettierignore
+++ b/extension/.prettierignore
@@ -5,3 +5,4 @@ package.json
 package-lock.json
 .prettierignore
 .eslintrc
+.nyc_output

--- a/extension/docs/ManualCapture.md
+++ b/extension/docs/ManualCapture.md
@@ -4,7 +4,8 @@
 - [Manual Capture](#manual-capture)
   - [Make an API call to capture a payment:](#make-an-api-call-to-capture-a-payment)
   - [Partial capture](#partial-capture)
-  - [More info](#more-info)
+  - [Retry capture requests](#retry-capture-requests)
+  - [More info on capture](#more-info-on-capture)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/extension/docs/ManualCapture.md
+++ b/extension/docs/ManualCapture.md
@@ -104,6 +104,39 @@ Once Adyen have processed your capture request, Adyen will send a notification t
 
 In order to enable multiple partial captures, it is necessary to contact Adyen Support team. For more info, see [Adyen's documentation](https://docs.adyen.com/online-payments/capture#multiple-partial-captures)
 
-### More info
+### Retry capture requests
+
+To be able to retry capture requests in case of failure, you need to add a custom field with key `idempotencyKey` to the custom type with key `ctp-adyen-integration-transaction-payment-type`. The `addTransaction` action will look like following:
+```
+{
+  "action": "addTransaction",
+  "transaction": {
+    "type": "Charge",
+    "amount": {
+      "currencyCode": "EUR",
+      "centAmount": 500
+    },
+    "state": "Initial",
+    "custom": {
+      "type": {
+        "typeId": "type",
+        "key": "ctp-adyen-integration-transaction-payment-type"
+      },
+      "fields": {
+        "idempotencyKey": "your-unique-idempotency-key"
+      }
+    }
+  }
+}
+```
+
+Follow these recommendations when using the idempotency key:
+- `idempotencyKey` must be unique per request so that in case the request fails, it can be retried with the same key. Additionally `idempotencyKey` is valid for a minimum period of 31 days after first submission (but may be retained for longer). Source:
+- Generate idempotency keys using the version 4 (random) UUID type to prevent two API credentials under the same account from accessing each others responses.
+- Use [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) when retrying.
+
+For in-depth information about API idempotency in Adyen, please check [the documentation from Adyen](https://docs.adyen.com/development-resources/api-idempotency)
+
+### More info on capture
 
 For more detailed information from Adyen's perspective, see [Adyen's documentation](https://docs.adyen.com/checkout/capture#manual-capture).

--- a/extension/docs/ManualCapture.md
+++ b/extension/docs/ManualCapture.md
@@ -107,6 +107,7 @@ In order to enable multiple partial captures, it is necessary to contact Adyen S
 ### Retry capture requests
 
 To be able to retry capture requests in case of failure, you need to add a custom field with key `idempotencyKey` to the custom type with key `ctp-adyen-integration-transaction-payment-type`. The `addTransaction` action will look like following:
+
 ```
 {
   "action": "addTransaction",
@@ -131,6 +132,7 @@ To be able to retry capture requests in case of failure, you need to add a custo
 ```
 
 Follow these recommendations when using the idempotency key:
+
 - `idempotencyKey` must be unique per request so that in case the request fails, it can be retried with the same key. Additionally `idempotencyKey` is valid for a minimum period of 31 days after first submission (but may be retained for longer). Source:
 - Generate idempotency keys using the version 4 (random) UUID type to prevent two API credentials under the same account from accessing each others responses.
 - Use [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) when retrying.

--- a/extension/docs/Refund.md
+++ b/extension/docs/Refund.md
@@ -147,6 +147,37 @@ By default, the refund reference field is taken from the payment key. If you nee
 }
 ```
 
+### Retry refund requests
+
+To be able to retry refund requests in case of failure, you need to add a custom field with key `idempotencyKey` to the custom type with key `ctp-adyen-integration-transaction-payment-type`. The `addTransaction` action will look like following:
+```
+{
+  "action": "addTransaction",
+  "transaction": {
+    "type": "Refund",
+    "amount": {
+      "currencyCode": "EUR",
+      "centAmount": 500
+    },
+    "state": "Initial",
+    "custom": {
+      "type": {
+        "typeId": "type",
+        "key": "ctp-adyen-integration-transaction-payment-type"
+      },
+      "fields": {
+        "idempotencyKey": "your-unique-idempotency-key"
+      }
+    }
+  }
+}
+```
+
+Follow these recommendations when using the idempotency key:
+- `idempotencyKey` must be unique per request so that in case the request fails, it can be retried with the same key. Additionally `idempotencyKey` is valid for a minimum period of 31 days after first submission (but may be retained for longer). Source:
+- Generate idempotency keys using the version 4 (random) UUID type to prevent two API credentials under the same account from accessing each others responses.
+- Use [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) when retrying.
+
 ### Additional information
 
 1. Don't add too many `Refund` transactions at once because [API Extension endpoint has a time limit](https://docs.commercetools.com/api/projects/api-extensions#time-limits).
@@ -159,3 +190,4 @@ By default, the refund reference field is taken from the payment key. If you nee
 
 1. [Adyen refund documentation](https://docs.adyen.com/checkout/refund)
 1. [Adyen refund API](https://docs.adyen.com/api-explorer/#/Payment/v68/post/refund)
+1. [API idempotency](https://docs.adyen.com/development-resources/api-idempotency)

--- a/extension/docs/Refund.md
+++ b/extension/docs/Refund.md
@@ -150,6 +150,7 @@ By default, the refund reference field is taken from the payment key. If you nee
 ### Retry refund requests
 
 To be able to retry refund requests in case of failure, you need to add a custom field with key `idempotencyKey` to the custom type with key `ctp-adyen-integration-transaction-payment-type`. The `addTransaction` action will look like following:
+
 ```
 {
   "action": "addTransaction",
@@ -174,6 +175,7 @@ To be able to retry refund requests in case of failure, you need to add a custom
 ```
 
 Follow these recommendations when using the idempotency key:
+
 - `idempotencyKey` must be unique per request so that in case the request fails, it can be retried with the same key. Additionally `idempotencyKey` is valid for a minimum period of 31 days after first submission (but may be retained for longer). Source:
 - Generate idempotency keys using the version 4 (random) UUID type to prevent two API credentials under the same account from accessing each others responses.
 - Use [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) when retrying.

--- a/extension/docs/Refund.md
+++ b/extension/docs/Refund.md
@@ -6,6 +6,7 @@
     - [Prerequisites](#prerequisites)
     - [Steps](#steps)
   - [Custom refund reference](#custom-refund-reference)
+  - [Retry refund requests](#retry-refund-requests)
   - [Additional information](#additional-information)
   - [Further resources](#further-resources)
 

--- a/extension/resources/payment-transaction-type.json
+++ b/extension/resources/payment-transaction-type.json
@@ -15,6 +15,17 @@
         "name": "String"
       },
       "inputHint": "SingleLine"
+    },
+    {
+      "name": "idempotencyKey",
+      "label": {
+        "en": "idempotencyKey"
+      },
+      "required": false,
+      "type": {
+        "name": "String"
+      },
+      "inputHint": "SingleLine"
     }
   ]
 }

--- a/extension/src/ctp.js
+++ b/extension/src/ctp.js
@@ -122,6 +122,10 @@ async function setUpClient(config) {
       return ctpClient.execute(this.buildRequestOptions(uri.build()))
     },
 
+    fetchById(uri, id) {
+      return ctpClient.execute(this.buildRequestOptions(uri.byId(id).build()))
+    },
+
     fetchByKey(uri, key) {
       return ctpClient.execute(this.buildRequestOptions(uri.byKey(key).build()))
     },

--- a/extension/src/paymentHandler/make-payment.handler.js
+++ b/extension/src/paymentHandler/make-payment.handler.js
@@ -33,7 +33,7 @@ async function execute(paymentObject) {
   ]
 
   const requestBodyJson = JSON.parse(request.body)
-  const paymentMethod = requestBodyJson.paymentMethod?.type
+  const paymentMethod = requestBodyJson?.paymentMethod?.type
   if (paymentMethod) {
     actions.push(createSetMethodInfoMethodAction(paymentMethod))
     const action = createSetMethodInfoNameAction(paymentMethod)

--- a/extension/src/paymentHandler/make-payment.handler.js
+++ b/extension/src/paymentHandler/make-payment.handler.js
@@ -32,7 +32,8 @@ async function execute(paymentObject) {
     ),
   ]
 
-  const paymentMethod = request.paymentMethod?.type
+  const requestBodyJson = JSON.parse(request.body)
+  const paymentMethod = requestBodyJson.paymentMethod?.type
   if (paymentMethod) {
     actions.push(createSetMethodInfoMethodAction(paymentMethod))
     const action = createSetMethodInfoNameAction(paymentMethod)
@@ -41,7 +42,7 @@ async function execute(paymentObject) {
 
   const paymentKey = paymentObject.key
   // ensure the key is a string, otherwise the error with "code": "InvalidJsonInput" will return by commercetools API.
-  const reference = request.reference.toString()
+  const reference = requestBodyJson.reference?.toString()
   // ensure the key and new reference is different, otherwise the error with
   // "code": "InvalidOperation", "message": "'key' has no changes." will return by commercetools API.
   if (reference !== paymentKey)

--- a/extension/src/paymentHandler/manual-capture.handler.js
+++ b/extension/src/paymentHandler/manual-capture.handler.js
@@ -21,13 +21,14 @@ async function execute(paymentObject) {
     },
     originalReference: authorizationSuccessTransaction.interactionId,
   }
-
+  const idempotencyKey = chargeInitialTransaction.custom?.fields?.idempotencyKey
   const adyenMerchantAccount = paymentObject.custom.fields.adyenMerchantAccount
   const commercetoolsProjectKey =
     paymentObject.custom.fields.commercetoolsProjectKey
   const { request, response } = await manualCapture(
     adyenMerchantAccount,
     commercetoolsProjectKey,
+    idempotencyKey,
     manualCaptureRequestObj
   )
 

--- a/extension/src/paymentHandler/payment-utils.js
+++ b/extension/src/paymentHandler/payment-utils.js
@@ -102,6 +102,7 @@ function createAddTransactionAction({
   amount,
   currency,
   interactionId,
+  custom,
 }) {
   return {
     action: 'addTransaction',
@@ -113,6 +114,7 @@ function createAddTransactionAction({
       },
       state,
       interactionId,
+      custom,
     },
   }
 }

--- a/extension/src/paymentHandler/refund-payment.handler.js
+++ b/extension/src/paymentHandler/refund-payment.handler.js
@@ -32,9 +32,11 @@ async function execute(paymentObject) {
           refundTransaction.custom?.fields?.reference || paymentObject.key,
       }
 
+      const idempotencyKey = refundTransaction.custom?.fields?.idempotencyKey
       const { request, response } = await refund(
         adyenMerchantAccount,
         commercetoolsProjectKey,
+        idempotencyKey,
         refundRequestObjects
       )
       const addInterfaceInteractionAction = createAddInterfaceInteractionAction(

--- a/extension/test/integration/affirm-make-payment.spec.js
+++ b/extension/test/integration/affirm-make-payment.spec.js
@@ -119,13 +119,16 @@ describe('::affirmMakePayment with multiple projects use case::', () => {
       updatedPayment.interfaceInteractions[0].fields
     const makePaymentRequest = JSON.parse(makePaymentInteraction.request)
     const makePaymentResponse = JSON.parse(makePaymentInteraction.response)
+    const makePaymentRequestBody = JSON.parse(makePaymentRequest.body)
 
-    expect(makePaymentRequest.metadata).to.deep.equal({
+    expect(makePaymentRequestBody.metadata).to.deep.equal({
       ctProjectKey: commercetoolsProjectKey,
     })
-    expect(makePaymentRequest.merchantAccount).to.be.equal(adyenMerchantAccount)
+    expect(makePaymentRequestBody.merchantAccount).to.be.equal(
+      adyenMerchantAccount
+    )
 
-    expect(makePaymentRequest.lineItems).to.have.lengthOf(3)
+    expect(makePaymentRequestBody.lineItems).to.have.lengthOf(3)
     expect(makePaymentResponse.resultCode).to.be.equal('RedirectShopper')
   }
 })

--- a/extension/test/integration/get-carbon-offset-costs.handler.spec.js
+++ b/extension/test/integration/get-carbon-offset-costs.handler.spec.js
@@ -112,7 +112,9 @@ describe('get-carbon-offset-costs', () => {
       interfaceInteraction.fields.response
     )
 
-    expect(JSON.parse(interfaceInteraction.fields.request)).to.be.deep.equal({
+    const request = JSON.parse(interfaceInteraction.fields.request)
+    const requestBody = JSON.parse(request.body)
+    expect(requestBody).to.be.deep.equal({
       merchantAccount: adyenMerchantAccount,
       ...getCarbonOffsetCostsRequestDraft,
     })

--- a/extension/test/integration/get-payment-methods.handler.spec.js
+++ b/extension/test/integration/get-payment-methods.handler.spec.js
@@ -89,7 +89,13 @@ describe('::getPaymentMethods::', () => {
         interfaceInteraction.fields.response
       )
 
-      expect(JSON.parse(interfaceInteraction.fields.request)).to.be.deep.equal({
+      const getPaymentMethodsRequestInteraction = JSON.parse(
+        interfaceInteraction.fields.request
+      )
+      const getPaymentMethodsRequestBody = JSON.parse(
+        getPaymentMethodsRequestInteraction.body
+      )
+      expect(getPaymentMethodsRequestBody).to.be.deep.equal({
         merchantAccount: adyenMerchantAccount,
         ...getPaymentMethodsRequestExtended,
       })
@@ -176,9 +182,13 @@ describe('::getPaymentMethods::', () => {
         paymentMethodsInteraction.fields.response
       )
 
-      expect(
-        JSON.parse(paymentMethodsInteraction.fields.request)
-      ).to.be.deep.equal({
+      const getPaymentMethodsRequestInteraction = JSON.parse(
+        paymentMethodsInteraction.fields.request
+      )
+      const getPaymentMethodsRequestBody = JSON.parse(
+        getPaymentMethodsRequestInteraction.body
+      )
+      expect(getPaymentMethodsRequestBody).to.be.deep.equal({
         merchantAccount: adyenMerchantAccount,
         ...getPaymentMethodsRequestExtended,
       })

--- a/extension/test/integration/klarna-make-payment.spec.js
+++ b/extension/test/integration/klarna-make-payment.spec.js
@@ -93,12 +93,16 @@ describe('::klarnaMakePayment with multiple projects use case::', () => {
     const makePaymentRequest = JSON.parse(makePaymentInteraction.request)
     const makePaymentResponse = JSON.parse(makePaymentInteraction.response)
 
-    expect(makePaymentRequest.metadata).to.deep.equal({
+    const makePaymentRequestBody = JSON.parse(makePaymentRequest.body)
+
+    expect(makePaymentRequestBody.metadata).to.deep.equal({
       ctProjectKey: commercetoolsProjectKey,
     })
-    expect(makePaymentRequest.merchantAccount).to.be.equal(adyenMerchantAccount)
+    expect(makePaymentRequestBody.merchantAccount).to.be.equal(
+      adyenMerchantAccount
+    )
 
-    expect(makePaymentRequest.lineItems).to.have.lengthOf(3)
+    expect(makePaymentRequestBody.lineItems).to.have.lengthOf(3)
     expect(makePaymentResponse.resultCode).to.be.equal('RedirectShopper')
   }
 })

--- a/extension/test/integration/klarna-make-payment.spec.js
+++ b/extension/test/integration/klarna-make-payment.spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 import ctpClientBuilder from '../../src/ctp.js'
 import config from '../../src/config/config.js'
 import { initPaymentWithCart } from './integration-test-set-up.js'
+import { updatePaymentWithRetry } from '../test-utils.js'
 
 describe('::klarnaMakePayment with multiple projects use case::', () => {
   const [commercetoolsProjectKey1, commercetoolsProjectKey2] =
@@ -74,17 +75,16 @@ describe('::klarnaMakePayment with multiple projects use case::', () => {
       returnUrl: 'https://www.yourshop.com/checkout/result',
     }
 
-    const { statusCode, body: updatedPayment } = await ctpClient.update(
-      ctpClient.builder.payments,
-      payment.id,
-      payment.version,
+    const { statusCode, updatedPayment } = await updatePaymentWithRetry(
+      ctpClient,
       [
         {
           action: 'setCustomField',
           name: 'makePaymentRequest',
           value: JSON.stringify(makePaymentRequestDraft),
         },
-      ]
+      ],
+      payment
     )
 
     expect(statusCode).to.be.equal(200)

--- a/extension/test/integration/make-payment.handler.spec.js
+++ b/extension/test/integration/make-payment.handler.spec.js
@@ -98,7 +98,8 @@ describe('::make-payment with multiple adyen accounts use case::', () => {
           constants.CTP_INTERACTION_TYPE_MAKE_PAYMENT
       )
       const makePaymentRequest = JSON.parse(interfaceInteraction.fields.request)
-      expect(makePaymentRequest.lineItems).to.have.lengthOf(3)
+      const makePaymentRequestBody = JSON.parse(makePaymentRequest.body)
+      expect(makePaymentRequestBody.lineItems).to.have.lengthOf(3)
     }
   )
 
@@ -156,18 +157,21 @@ describe('::make-payment with multiple adyen accounts use case::', () => {
         interaction.fields.type === constants.CTP_INTERACTION_TYPE_MAKE_PAYMENT
     )
     const makePaymentRequest = JSON.parse(interfaceInteraction.fields.request)
+    const makePaymentRequestBody = JSON.parse(makePaymentRequest.body)
     if (metadata) {
-      expect(makePaymentRequest.metadata).to.deep.equal({
+      expect(makePaymentRequestBody.metadata).to.deep.equal({
         ctProjectKey: commercetoolsProjectKey,
         ...metadata,
       })
     } else {
-      expect(makePaymentRequest.metadata).to.deep.equal({
+      expect(makePaymentRequestBody.metadata).to.deep.equal({
         ctProjectKey: commercetoolsProjectKey,
       })
     }
 
-    expect(makePaymentRequest.merchantAccount).to.be.equal(adyenMerchantAccount)
+    expect(makePaymentRequestBody.merchantAccount).to.be.equal(
+      adyenMerchantAccount
+    )
 
     const { makePaymentResponse } = payment.custom.fields
 

--- a/extension/test/integration/manual-capture.spec.js
+++ b/extension/test/integration/manual-capture.spec.js
@@ -1,9 +1,9 @@
 import { expect } from 'chai'
+import crypto from 'crypto'
 import ctpClientBuilder from '../../src/ctp.js'
 import constants from '../../src/config/constants.js'
 import { createAddTransactionAction } from '../../src/paymentHandler/payment-utils.js'
 import config from '../../src/config/config.js'
-import crypto from 'crypto'
 
 const {
   CTP_ADYEN_INTEGRATION,
@@ -81,7 +81,7 @@ describe('::manualCapture::', () => {
                 key: 'ctp-adyen-integration-transaction-payment-type',
               },
               fields: {
-                idempotencyKey: idempotencyKey,
+                idempotencyKey,
               },
             },
           }),

--- a/extension/test/integration/refund-payment.handler.spec.js
+++ b/extension/test/integration/refund-payment.handler.spec.js
@@ -1,9 +1,9 @@
 import { expect } from 'chai'
+import crypto from 'crypto'
 import ctpClientBuilder from '../../src/ctp.js'
 import constants from '../../src/config/constants.js'
 import { createAddTransactionAction } from '../../src/paymentHandler/payment-utils.js'
 import config from '../../src/config/config.js'
-import crypto from 'crypto'
 
 const {
   CTP_ADYEN_INTEGRATION,
@@ -135,7 +135,9 @@ describe('::refund::', () => {
         )
         expect(refundTransaction).to.exist
         const adyenRequest = JSON.parse(interfaceInteraction.fields.request)
-        expect(adyenRequest.headers['Idempotency-Key']).to.equal(refundTransaction.custom?.fields?.idempotencyKey)
+        expect(adyenRequest.headers['Idempotency-Key']).to.equal(
+          refundTransaction.custom?.fields?.idempotencyKey
+        )
       }
     }
   )

--- a/extension/test/integration/refund-payment.handler.spec.js
+++ b/extension/test/integration/refund-payment.handler.spec.js
@@ -3,6 +3,7 @@ import ctpClientBuilder from '../../src/ctp.js'
 import constants from '../../src/config/constants.js'
 import { createAddTransactionAction } from '../../src/paymentHandler/payment-utils.js'
 import config from '../../src/config/config.js'
+import crypto from 'crypto'
 
 const {
   CTP_ADYEN_INTEGRATION,
@@ -13,6 +14,8 @@ const {
 describe('::refund::', () => {
   const commercetoolsProjectKey = config.getAllCtpProjectKeys()[0]
   const adyenMerchantAccount = config.getAllAdyenMerchantAccounts()[0]
+  const idempotencyKey1 = crypto.randomBytes(20).toString('hex')
+  const idempotencyKey2 = crypto.randomBytes(20).toString('hex')
   let ctpClient
 
   beforeEach(async () => {
@@ -72,12 +75,30 @@ describe('::refund::', () => {
             state: 'Initial',
             currency: 'EUR',
             amount: 500,
+            custom: {
+              type: {
+                typeId: 'type',
+                key: 'ctp-adyen-integration-transaction-payment-type',
+              },
+              fields: {
+                idempotencyKey: idempotencyKey1,
+              },
+            },
           }),
           createAddTransactionAction({
             type: 'Refund',
             state: 'Initial',
             currency: 'EUR',
             amount: 300,
+            custom: {
+              type: {
+                typeId: 'type',
+                key: 'ctp-adyen-integration-transaction-payment-type',
+              },
+              fields: {
+                idempotencyKey: idempotencyKey2,
+              },
+            },
           }),
           createAddTransactionAction({
             type: 'Refund',
@@ -113,6 +134,8 @@ describe('::refund::', () => {
             transaction.interactionId === adyenResponse.pspReference
         )
         expect(refundTransaction).to.exist
+        const adyenRequest = JSON.parse(interfaceInteraction.fields.request)
+        expect(adyenRequest.headers['Idempotency-Key']).to.equal(refundTransaction.custom?.fields?.idempotencyKey)
       }
     }
   )

--- a/extension/test/unit/get-carbon-offset-costs.handler.spec.js
+++ b/extension/test/unit/get-carbon-offset-costs.handler.spec.js
@@ -64,7 +64,8 @@ describe('get-carbon-offset-costs::execute::', () => {
     expect(result.actions.length).to.equal(2)
     expect(result.actions[0].action).to.equal('addInterfaceInteraction')
     expect(result.actions[1].action).to.equal('setCustomField')
-    expect(JSON.parse(result.actions[0].fields.request)).to.be.deep.includes(
+    const request = JSON.parse(result.actions[0].fields.request)
+    expect(JSON.parse(request.body)).to.be.deep.includes(
       getCarbonOffsetCostsRequest
     )
     expect(result.actions[0].fields.response).to.be.deep.equal(
@@ -98,7 +99,8 @@ describe('get-carbon-offset-costs::execute::', () => {
       expect(result.actions.length).to.equal(2)
       expect(result.actions[0].action).to.equal('addInterfaceInteraction')
       expect(result.actions[1].action).to.equal('setCustomField')
-      expect(JSON.parse(result.actions[0].fields.request)).to.be.deep.includes(
+      const request = JSON.parse(result.actions[0].fields.request)
+      expect(JSON.parse(request.body)).to.be.deep.includes(
         getCarbonOffsetCostsRequest
       )
       expect(result.actions[0].fields.response).to.equal(

--- a/extension/test/unit/get-payment-methods.handler.spec.js
+++ b/extension/test/unit/get-payment-methods.handler.spec.js
@@ -67,7 +67,8 @@ describe('get-payment-methods::execute::', () => {
     expect(result.actions.length).to.equal(2)
     expect(result.actions[0].action).to.equal('addInterfaceInteraction')
     expect(result.actions[1].action).to.equal('setCustomField')
-    expect(JSON.parse(result.actions[0].fields.request)).to.be.deep.includes(
+    const request = JSON.parse(result.actions[0].fields.request)
+    expect(JSON.parse(request.body)).to.be.deep.includes(
       getPaymentMethodsRequest
     )
     expect(result.actions[0].fields.response).to.be.deep.equal(
@@ -100,7 +101,8 @@ describe('get-payment-methods::execute::', () => {
       expect(result.actions.length).to.equal(2)
       expect(result.actions[0].action).to.equal('addInterfaceInteraction')
       expect(result.actions[1].action).to.equal('setCustomField')
-      expect(JSON.parse(result.actions[0].fields.request)).to.be.deep.includes(
+      const request = JSON.parse(result.actions[0].fields.request)
+      expect(JSON.parse(request.body)).to.be.deep.includes(
         getPaymentMethodsRequest
       )
       expect(result.actions[0].fields.response).to.be.includes(errorMsg)

--- a/extension/test/unit/make-lineitems-payment.handler.spec.js
+++ b/extension/test/unit/make-lineitems-payment.handler.spec.js
@@ -68,8 +68,11 @@ describe('make-lineitems-payment::execute', () => {
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
+      const makePaymentRequestJson = JSON.parse(
+        makePaymentRequestInteraction.body
+      )
       const ctpLineItem = ctpCart.lineItems[0]
-      const adyenLineItem = makePaymentRequestInteraction.lineItems.find(
+      const adyenLineItem = makePaymentRequestJson.lineItems.find(
         (item) => item.id === 'test-product-sku-1'
       )
       expect(ctpLineItem.price.value.centAmount).to.equal(
@@ -90,7 +93,7 @@ describe('make-lineitems-payment::execute', () => {
       expect(setMethodInfoName.name).to.eql({ en: 'Klarna' })
 
       const ctpShippingInfo = ctpCart.shippingInfo
-      const adyenShippingInfo = makePaymentRequestInteraction.lineItems.find(
+      const adyenShippingInfo = makePaymentRequestJson.lineItems.find(
         (item) => item.id === ctpShippingInfo.shippingMethodName
       )
       expect(ctpShippingInfo.price.centAmount).to.equal(
@@ -132,8 +135,11 @@ describe('make-lineitems-payment::execute', () => {
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
+      const makePaymentRequestJson = JSON.parse(
+        makePaymentRequestInteraction.body
+      )
       const ctpLineItem = ctpCart.lineItems[0]
-      const adyenLineItem = makePaymentRequestInteraction.lineItems.find(
+      const adyenLineItem = makePaymentRequestJson.lineItems.find(
         (item) => item.id === 'test-product-sku-1'
       )
       expect(ctpLineItem.price.value.centAmount).to.equal(
@@ -154,7 +160,7 @@ describe('make-lineitems-payment::execute', () => {
       expect(setMethodInfoName.name).to.eql({ en: 'Affirm' })
 
       const ctpShippingInfo = ctpCart.shippingInfo
-      const adyenShippingInfo = makePaymentRequestInteraction.lineItems.find(
+      const adyenShippingInfo = makePaymentRequestJson.lineItems.find(
         (item) => item.id === ctpShippingInfo.shippingMethodName
       )
       expect(ctpShippingInfo.price.centAmount).to.equal(
@@ -196,7 +202,10 @@ describe('make-lineitems-payment::execute', () => {
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
-      expect(makePaymentRequestInteraction.lineItems).to.deep.equal(
+      const makePaymentRequestJson = JSON.parse(
+        makePaymentRequestInteraction.body
+      )
+      expect(makePaymentRequestJson.lineItems).to.deep.equal(
         klarnaMakePaymentRequest.lineItems
       )
     }
@@ -232,7 +241,10 @@ describe('make-lineitems-payment::execute', () => {
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
-      expect(makePaymentRequestInteraction.lineItems).to.deep.equal(
+      const makePaymentRequestJson = JSON.parse(
+        makePaymentRequestInteraction.body
+      )
+      expect(makePaymentRequestJson.lineItems).to.deep.equal(
         affirmMakePaymentRequest.lineItems
       )
     }
@@ -259,10 +271,11 @@ describe('make-lineitems-payment::execute', () => {
       const response = await makeLineItemsPaymentHandler.execute(
         ctpPaymentToTest
       )
-      const { lineItems } = JSON.parse(
+      const makePaymentRequestInteraction = JSON.parse(
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
+      const { lineItems } = JSON.parse(makePaymentRequestInteraction.body)
       expect(lineItems).to.have.lengthOf(3)
       expect(lineItems[0].description).to.equal(
         Object.values(ctpCart.lineItems[0].name)[0]
@@ -300,10 +313,11 @@ describe('make-lineitems-payment::execute', () => {
       const response = await makeLineItemsPaymentHandler.execute(
         ctpPaymentToTest
       )
-      const { lineItems } = JSON.parse(
+      const makePaymentRequestInteraction = JSON.parse(
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
+      const { lineItems } = JSON.parse(makePaymentRequestInteraction.body)
       expect(lineItems[2].description).to.equal(
         ctpCart.shippingInfo.shippingMethodName
       )
@@ -337,10 +351,11 @@ describe('make-lineitems-payment::execute', () => {
         ctpPaymentClone
       )
       expect(response.actions).to.have.lengthOf(6)
-      const { lineItems } = JSON.parse(
+      const makePaymentRequestInteraction = JSON.parse(
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
+      const { lineItems } = JSON.parse(makePaymentRequestInteraction.body)
       const shippingMethodItem = lineItems[lineItems.length - 1]
       expect(shippingMethodItem.id).to.equal(
         ctpCartWithCustomShippingMethod.shippingInfo.shippingMethodName
@@ -381,10 +396,11 @@ describe('make-lineitems-payment::execute', () => {
         ctpPaymentClone
       )
       expect(response.actions).to.have.lengthOf(6)
-      const { lineItems } = JSON.parse(
+      const makePaymentRequestInteraction = JSON.parse(
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
+      const { lineItems } = JSON.parse(makePaymentRequestInteraction.body)
       const shippingMethodItem = lineItems[lineItems.length - 1]
       expect(shippingMethodItem.id).to.equal(
         ctpCartWithCustomShippingMethod.shippingInfo.shippingMethodName
@@ -421,10 +437,11 @@ describe('make-lineitems-payment::execute', () => {
       },
     }
     const response = await makeLineItemsPaymentHandler.execute(ctpPaymentToTest)
-    const { lineItems } = JSON.parse(
+    const makePaymentRequestInteraction = JSON.parse(
       response.actions.find((a) => a.action === 'addInterfaceInteraction')
         .fields.request
     )
+    const { lineItems } = JSON.parse(makePaymentRequestInteraction.body)
     expect(lineItems[0].description).to.equal('test-de')
   })
 
@@ -456,10 +473,11 @@ describe('make-lineitems-payment::execute', () => {
       const response = await makeLineItemsPaymentHandler.execute(
         ctpPaymentToTest
       )
-      const { lineItems } = JSON.parse(
+      const makePaymentRequestInteraction = JSON.parse(
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
+      const { lineItems } = JSON.parse(makePaymentRequestInteraction.body)
       expect(lineItems[0].description).to.equal('test-fr')
     }
   )
@@ -491,10 +509,11 @@ describe('make-lineitems-payment::execute', () => {
       const response = await makeLineItemsPaymentHandler.execute(
         ctpPaymentToTest
       )
-      const { lineItems } = JSON.parse(
+      const makePaymentRequestInteraction = JSON.parse(
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
+      const { lineItems } = JSON.parse(makePaymentRequestInteraction.body)
       expect(lineItems[0].description).to.equal('test-de')
     }
   )

--- a/extension/test/unit/make-payment-with-splits.handler.spec.js
+++ b/extension/test/unit/make-payment-with-splits.handler.spec.js
@@ -110,20 +110,23 @@ describe('make-payment-with-splits::execute', () => {
       expect(addInterfaceInteraction.fields.createdAt).to.be.a('string')
 
       const request = JSON.parse(addInterfaceInteraction.fields.request)
-      expect(request.reference).to.deep.equal(
+      const requestBody = JSON.parse(request.body)
+      expect(requestBody.reference).to.deep.equal(
         makePaymentWithSplitsRequest.reference
       )
-      expect(request.riskData).to.deep.equal(
+      expect(requestBody.riskData).to.deep.equal(
         makePaymentWithSplitsRequest.riskData
       )
-      expect(request.paymentMethod).to.deep.equal(
+      expect(requestBody.paymentMethod).to.deep.equal(
         makePaymentWithSplitsRequest.paymentMethod
       )
-      expect(request.browserInfo).to.deep.equal(
+      expect(requestBody.browserInfo).to.deep.equal(
         makePaymentWithSplitsRequest.browserInfo
       )
-      expect(request.amount).to.deep.equal(makePaymentWithSplitsRequest.amount)
-      expect(request.merchantAccount).to.equal(adyenMerchantAccount)
+      expect(requestBody.amount).to.deep.equal(
+        makePaymentWithSplitsRequest.amount
+      )
+      expect(requestBody.merchantAccount).to.equal(adyenMerchantAccount)
 
       const setCustomFieldAction = response.actions.find(
         (a) => a.action === 'setCustomField'

--- a/extension/test/unit/make-payment.handler.spec.js
+++ b/extension/test/unit/make-payment.handler.spec.js
@@ -102,14 +102,17 @@ describe('make-payment::execute', () => {
       expect(addInterfaceInteraction.fields.createdAt).to.be.a('string')
 
       const request = JSON.parse(addInterfaceInteraction.fields.request)
-      expect(request.reference).to.deep.equal(makePaymentRequest.reference)
-      expect(request.riskData).to.deep.equal(makePaymentRequest.riskData)
-      expect(request.paymentMethod).to.deep.equal(
+      const requestBody = JSON.parse(request.body)
+      expect(requestBody.reference).to.deep.equal(makePaymentRequest.reference)
+      expect(requestBody.riskData).to.deep.equal(makePaymentRequest.riskData)
+      expect(requestBody.paymentMethod).to.deep.equal(
         makePaymentRequest.paymentMethod
       )
-      expect(request.browserInfo).to.deep.equal(makePaymentRequest.browserInfo)
-      expect(request.amount).to.deep.equal(makePaymentRequest.amount)
-      expect(request.merchantAccount).to.equal(adyenMerchantAccount)
+      expect(requestBody.browserInfo).to.deep.equal(
+        makePaymentRequest.browserInfo
+      )
+      expect(requestBody.amount).to.deep.equal(makePaymentRequest.amount)
+      expect(requestBody.merchantAccount).to.equal(adyenMerchantAccount)
 
       const setCustomFieldAction = response.actions.find(
         (a) => a.action === 'setCustomField'
@@ -159,14 +162,17 @@ describe('make-payment::execute', () => {
       expect(addInterfaceInteraction.fields.createdAt).to.be.a('string')
 
       const request = JSON.parse(addInterfaceInteraction.fields.request)
-      expect(request.reference).to.deep.equal(makePaymentRequest.reference)
-      expect(request.riskData).to.deep.equal(makePaymentRequest.riskData)
-      expect(request.paymentMethod).to.deep.equal(
+      const requestBody = JSON.parse(request.body)
+      expect(requestBody.reference).to.deep.equal(makePaymentRequest.reference)
+      expect(requestBody.riskData).to.deep.equal(makePaymentRequest.riskData)
+      expect(requestBody.paymentMethod).to.deep.equal(
         makePaymentRequest.paymentMethod
       )
-      expect(request.browserInfo).to.deep.equal(makePaymentRequest.browserInfo)
-      expect(request.amount).to.deep.equal(makePaymentRequest.amount)
-      expect(request.merchantAccount).to.equal(adyenMerchantAccount)
+      expect(requestBody.browserInfo).to.deep.equal(
+        makePaymentRequest.browserInfo
+      )
+      expect(requestBody.amount).to.deep.equal(makePaymentRequest.amount)
+      expect(requestBody.merchantAccount).to.equal(adyenMerchantAccount)
 
       const setCustomFieldAction = response.actions.find(
         (a) => a.action === 'setCustomField'
@@ -206,14 +212,17 @@ describe('make-payment::execute', () => {
       expect(addInterfaceInteraction.fields.createdAt).to.be.a('string')
 
       const request = JSON.parse(addInterfaceInteraction.fields.request)
-      expect(request.reference).to.deep.equal(makePaymentRequest.reference)
-      expect(request.riskData).to.deep.equal(makePaymentRequest.riskData)
-      expect(request.paymentMethod).to.deep.equal(
+      const requestBody = JSON.parse(request.body)
+      expect(requestBody.reference).to.deep.equal(makePaymentRequest.reference)
+      expect(requestBody.riskData).to.deep.equal(makePaymentRequest.riskData)
+      expect(requestBody.paymentMethod).to.deep.equal(
         makePaymentRequest.paymentMethod
       )
-      expect(request.browserInfo).to.deep.equal(makePaymentRequest.browserInfo)
-      expect(request.amount).to.deep.equal(makePaymentRequest.amount)
-      expect(request.merchantAccount).to.equal(adyenMerchantAccount)
+      expect(requestBody.browserInfo).to.deep.equal(
+        makePaymentRequest.browserInfo
+      )
+      expect(requestBody.amount).to.deep.equal(makePaymentRequest.amount)
+      expect(requestBody.merchantAccount).to.equal(adyenMerchantAccount)
 
       const setCustomFieldAction = response.actions.find(
         (a) => a.action === 'setCustomField'
@@ -254,14 +263,17 @@ describe('make-payment::execute', () => {
       expect(addInterfaceInteraction.fields.createdAt).to.be.a('string')
 
       const request = JSON.parse(addInterfaceInteraction.fields.request)
-      expect(request.reference).to.deep.equal(makePaymentRequest.reference)
-      expect(request.riskData).to.deep.equal(makePaymentRequest.riskData)
-      expect(request.paymentMethod).to.deep.equal(
+      const requestBody = JSON.parse(request.body)
+      expect(requestBody.reference).to.deep.equal(makePaymentRequest.reference)
+      expect(requestBody.riskData).to.deep.equal(makePaymentRequest.riskData)
+      expect(requestBody.paymentMethod).to.deep.equal(
         makePaymentRequest.paymentMethod
       )
-      expect(request.browserInfo).to.deep.equal(makePaymentRequest.browserInfo)
-      expect(request.amount).to.deep.equal(makePaymentRequest.amount)
-      expect(request.merchantAccount).to.equal(adyenMerchantAccount)
+      expect(requestBody.browserInfo).to.deep.equal(
+        makePaymentRequest.browserInfo
+      )
+      expect(requestBody.amount).to.deep.equal(makePaymentRequest.amount)
+      expect(requestBody.merchantAccount).to.equal(adyenMerchantAccount)
 
       const setCustomFieldAction = response.actions.find(
         (a) => a.action === 'setCustomField'
@@ -312,14 +324,17 @@ describe('make-payment::execute', () => {
       expect(addInterfaceInteraction.fields.createdAt).to.be.a('string')
 
       const request = JSON.parse(addInterfaceInteraction.fields.request)
-      expect(request.reference).to.deep.equal(makePaymentRequest.reference)
-      expect(request.riskData).to.deep.equal(makePaymentRequest.riskData)
-      expect(request.paymentMethod).to.deep.equal(
+      const requestBody = JSON.parse(request.body)
+      expect(requestBody.reference).to.deep.equal(makePaymentRequest.reference)
+      expect(requestBody.riskData).to.deep.equal(makePaymentRequest.riskData)
+      expect(requestBody.paymentMethod).to.deep.equal(
         makePaymentRequest.paymentMethod
       )
-      expect(request.browserInfo).to.deep.equal(makePaymentRequest.browserInfo)
-      expect(request.amount).to.deep.equal(makePaymentRequest.amount)
-      expect(request.merchantAccount).to.equal(adyenMerchantAccount)
+      expect(requestBody.browserInfo).to.deep.equal(
+        makePaymentRequest.browserInfo
+      )
+      expect(requestBody.amount).to.deep.equal(makePaymentRequest.amount)
+      expect(requestBody.merchantAccount).to.equal(adyenMerchantAccount)
 
       const setCustomFieldAction = response.actions.find(
         (a) => a.action === 'setCustomField'

--- a/extension/test/unit/multitenancy.spec.js
+++ b/extension/test/unit/multitenancy.spec.js
@@ -57,7 +57,8 @@ describe('::Multitenancy::', () => {
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
-      expect(adyenRequest.merchantAccount).to.equal(adyenMerchantAccount)
+      const adyenRequestBody = JSON.parse(adyenRequest.body)
+      expect(adyenRequestBody.merchantAccount).to.equal(adyenMerchantAccount)
       expect(ctpApiScope.isDone()).to.be.true
     }
   )

--- a/extension/test/unit/payment-handler-lineItems.spec.js
+++ b/extension/test/unit/payment-handler-lineItems.spec.js
@@ -70,7 +70,10 @@ describe('payment-handler-lineItems::execute', () => {
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
-      expect(makePaymentRequestInteraction.lineItems).to.have.lengthOf(3)
+      const makePaymentRequestJson = JSON.parse(
+        makePaymentRequestInteraction.body
+      )
+      expect(makePaymentRequestJson.lineItems).to.have.lengthOf(3)
     }
   )
 
@@ -106,7 +109,10 @@ describe('payment-handler-lineItems::execute', () => {
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
-      expect(makePaymentRequestInteraction.lineItems).to.have.lengthOf(3)
+      const makePaymentRequestJson = JSON.parse(
+        makePaymentRequestInteraction.body
+      )
+      expect(makePaymentRequestJson.lineItems).to.have.lengthOf(3)
     }
   )
 
@@ -141,7 +147,10 @@ describe('payment-handler-lineItems::execute', () => {
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
-      expect(makePaymentRequestInteraction.lineItems).to.undefined
+      const makePaymentRequestJson = JSON.parse(
+        makePaymentRequestInteraction.body
+      )
+      expect(makePaymentRequestJson.lineItems).to.undefined
     }
   )
 
@@ -175,7 +184,10 @@ describe('payment-handler-lineItems::execute', () => {
         response.actions.find((a) => a.action === 'addInterfaceInteraction')
           .fields.request
       )
-      expect(makePaymentRequestInteraction.lineItems).to.have.lengthOf(3)
+      const makePaymentRequestJson = JSON.parse(
+        makePaymentRequestInteraction.body
+      )
+      expect(makePaymentRequestJson.lineItems).to.have.lengthOf(3)
     }
   )
 

--- a/extension/test/unit/refund-payment.handler.spec.js
+++ b/extension/test/unit/refund-payment.handler.spec.js
@@ -63,8 +63,9 @@ describe('refund-payment::execute', () => {
       (action) => action.action === 'addInterfaceInteraction'
     ).fields.request
     const adyenRequestJson = JSON.parse(adyenRequest)
+    const requestBody = JSON.parse(adyenRequestJson.body)
 
-    expect(adyenRequestJson.reference).to.equal(
+    expect(requestBody.reference).to.equal(
       refundPaymentTransaction.custom.fields.reference
     )
   })

--- a/extension/test/unit/submit-payment-details.handler.spec.js
+++ b/extension/test/unit/submit-payment-details.handler.spec.js
@@ -71,20 +71,23 @@ describe('submit-additional-payment-details::execute', () => {
       expect(addInterfaceInteraction.fields.createdAt).to.be.a('string')
 
       const request = JSON.parse(addInterfaceInteraction.fields.request)
-      expect(request.reference).to.deep.equal(
+      const requestBody = JSON.parse(request.body)
+      expect(requestBody.reference).to.deep.equal(
         submitPaymentDetailsRequest.reference
       )
-      expect(request.riskData).to.deep.equal(
+      expect(requestBody.riskData).to.deep.equal(
         submitPaymentDetailsRequest.riskData
       )
-      expect(request.paymentMethod).to.deep.equal(
+      expect(requestBody.paymentMethod).to.deep.equal(
         submitPaymentDetailsRequest.paymentMethod
       )
-      expect(request.browserInfo).to.deep.equal(
+      expect(requestBody.browserInfo).to.deep.equal(
         submitPaymentDetailsRequest.browserInfo
       )
-      expect(request.amount).to.deep.equal(submitPaymentDetailsRequest.amount)
-      expect(request.merchantAccount).to.equal(adyenMerchantAccount)
+      expect(requestBody.amount).to.deep.equal(
+        submitPaymentDetailsRequest.amount
+      )
+      expect(requestBody.merchantAccount).to.equal(adyenMerchantAccount)
 
       const setCustomFieldAction = response.actions.find(
         (a) => a.action === 'setCustomField'
@@ -147,20 +150,23 @@ describe('submit-additional-payment-details::execute', () => {
       expect(addInterfaceInteraction.fields.createdAt).to.be.a('string')
 
       const request = JSON.parse(addInterfaceInteraction.fields.request)
-      expect(request.reference).to.deep.equal(
+      const requestBody = JSON.parse(request.body)
+      expect(requestBody.reference).to.deep.equal(
         submitPaymentDetailsRequest.reference
       )
-      expect(request.riskData).to.deep.equal(
+      expect(requestBody.riskData).to.deep.equal(
         submitPaymentDetailsRequest.riskData
       )
-      expect(request.paymentMethod).to.deep.equal(
+      expect(requestBody.paymentMethod).to.deep.equal(
         submitPaymentDetailsRequest.paymentMethod
       )
-      expect(request.browserInfo).to.deep.equal(
+      expect(requestBody.browserInfo).to.deep.equal(
         submitPaymentDetailsRequest.browserInfo
       )
-      expect(request.amount).to.deep.equal(submitPaymentDetailsRequest.amount)
-      expect(request.merchantAccount).to.equal(adyenMerchantAccount)
+      expect(requestBody.amount).to.deep.equal(
+        submitPaymentDetailsRequest.amount
+      )
+      expect(requestBody.merchantAccount).to.equal(adyenMerchantAccount)
 
       const setCustomFieldAction = response.actions.find(
         (a) => a.action === 'setCustomField'
@@ -202,7 +208,8 @@ describe('submit-additional-payment-details::execute', () => {
         (a) => a.action === 'addInterfaceInteraction'
       )
       const request = JSON.parse(addInterfaceInteraction.fields.request)
-      expect(request.paymentData).to.equal(
+      const requestBody = JSON.parse(request.body)
+      expect(requestBody.paymentData).to.equal(
         JSON.parse(makePaymentRedirectResponse).paymentData
       )
     }
@@ -233,7 +240,8 @@ describe('submit-additional-payment-details::execute', () => {
         (a) => a.action === 'addInterfaceInteraction'
       )
       const request = JSON.parse(addInterfaceInteraction.fields.request)
-      expect(request.paymentData).to.equal(testPaymentData)
+      const requestBody = JSON.parse(request.body)
+      expect(requestBody.paymentData).to.equal(testPaymentData)
     }
   )
 

--- a/notification/.prettierignore
+++ b/notification/.prettierignore
@@ -5,4 +5,3 @@ package.json
 package-lock.json
 .prettierignore
 .eslintrc
-.nyc_output

--- a/notification/.prettierignore
+++ b/notification/.prettierignore
@@ -5,3 +5,4 @@ package.json
 package-lock.json
 .prettierignore
 .eslintrc
+.nyc_output


### PR DESCRIPTION
Related doc from adyen: https://docs.adyen.com/development-resources/api-idempotency

Boy-scout change: I also tried to fix one frequently failing test: https://github.com/commercetools/commercetools-adyen-integration/runs/7915704142?check_suite_focus=true#step:11:247

Addressing the issue: https://github.com/commercetools/commercetools-adyen-integration/issues/930
