### PR TITLE
Check if transaction exists before creating an update action

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commercetools-adyen-integration-extension",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "commercetools-adyen-integration-extension",
-      "version": "10.0.1",
+      "version": "10.0.2",
       "license": "MIT",
       "dependencies": {
         "@commercetools/api-request-builder": "6.0.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commercetools-adyen-integration-extension",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "description": "Integration between commercetools and Adyen payment service provider",
   "license": "MIT",
   "type": "module",

--- a/extension/src/paymentHandler/submit-payment-details.handler.js
+++ b/extension/src/paymentHandler/submit-payment-details.handler.js
@@ -42,13 +42,17 @@ async function execute(paymentObject) {
       )
     )
 
-    const addTransactionAction = createAddTransactionActionByResponse(
-      paymentObject.amountPlanned.centAmount,
-      paymentObject.amountPlanned.currencyCode,
-      response
-    )
+    if (
+      !_hasTransactionWithPspReference(response.pspReference, paymentObject)
+    ) {
+      const addTransactionAction = createAddTransactionActionByResponse(
+        paymentObject.amountPlanned.centAmount,
+        paymentObject.amountPlanned.currencyCode,
+        response
+      )
 
-    if (addTransactionAction) actions.push(addTransactionAction)
+      if (addTransactionAction) actions.push(addTransactionAction)
+    }
   }
   return {
     actions,
@@ -80,6 +84,12 @@ function _isNewRequest(
   }
 
   return false
+}
+
+function _hasTransactionWithPspReference(pspReference, paymentObject) {
+  return paymentObject.transactions.some(
+    (transaction) => transaction.interactionId === pspReference
+  )
 }
 
 export default { execute }

--- a/notification/package-lock.json
+++ b/notification/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commercetools-adyen-integration-notification",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "commercetools-adyen-integration-notification",
-      "version": "10.0.1",
+      "version": "10.0.2",
       "dependencies": {
         "@adyen/api-library": "12.0.0",
         "@commercetools/api-request-builder": "6.0.0",

--- a/notification/package.json
+++ b/notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commercetools-adyen-integration-notification",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "description": "Part of the integration of Adyen with commercetools responsible to receive and process notifications from Adyen",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
This PR prevents creating a new transaction when a transaction with the same interactionId already exists.