### PR TITLE
Remove mocha exit param

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -81,7 +81,6 @@
   },
   "mocha": {
     "timeout": 120000,
-    "exit": true,
     "full-trace": true
   },
   "husky": {


### PR DESCRIPTION
Remove `--exit` mocha param as it is redundant: https://mochajs.org/#-exit