### PR TITLE
Notification management api

### DIFF
--- a/extension/test/e2e/pageObjects/AffirmPage.js
+++ b/extension/test/e2e/pageObjects/AffirmPage.js
@@ -31,7 +31,7 @@ export default class AffirmPage {
     const autoPayToggle = await this.page.$('#autopay-toggle')
     await this.page.evaluate((cb) => cb.click(), autoPayToggle)
     await this.page.waitForTimeout(1_000) // Wait for the page refreshes after toggling the autopay
-    const confirmCheckbox = await this.page.$('#confirm-disclosure-checkbox')
+    const confirmCheckbox = await this.page.$('[data-testid="disclosure-checkbox-indicator"]')
     await this.page.evaluate((cb) => cb.click(), confirmCheckbox)
     await this.page.click('[data-testid="submit-button"]')
   }

--- a/extension/test/e2e/pageObjects/AffirmPage.js
+++ b/extension/test/e2e/pageObjects/AffirmPage.js
@@ -31,7 +31,9 @@ export default class AffirmPage {
     const autoPayToggle = await this.page.$('#autopay-toggle')
     await this.page.evaluate((cb) => cb.click(), autoPayToggle)
     await this.page.waitForTimeout(1_000) // Wait for the page refreshes after toggling the autopay
-    const confirmCheckbox = await this.page.$('[data-testid="disclosure-checkbox-indicator"]')
+    const confirmCheckbox = await this.page.$(
+      '[data-testid="disclosure-checkbox-indicator"]'
+    )
     await this.page.evaluate((cb) => cb.click(), confirmCheckbox)
     await this.page.click('[data-testid="submit-button"]')
   }

--- a/notification/docs/HowToRun.md
+++ b/notification/docs/HowToRun.md
@@ -99,13 +99,15 @@ Other configurations can be set as direct child attributes in `ADYEN_INTEGRATION
 }
 ```
 
-| Name                         | Content                                                                                                                                                                         | Required | Default value                                                                                         |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
-| `adyenPaymentMethodsToNames` | Key-value object where key is `paymentMethod` returned in the notification and value is the custom localized name that will be saved in CTP `payment.paymentMethodInfo.method`. | NO       | `{scheme: {en: 'Credit Card'}, pp: {en: 'PayPal'}, klarna: {en: 'Klarna'}, gpay: {en: 'Google Pay'}}` |
-| `port`                       | The port number on which the application will run.                                                                                                                              | NO       | 443                                                                                                   |
-| `logLevel`                   | The log level (`trace`, `debug`, `info`, `warn`, `error`, `fatal`).                                                                                                             | NO       | `info`                                                                                                |
-| `keepAliveTimeout`           | Milliseconds to keep a socket alive after the last response ([Node.js docs](https://nodejs.org/dist/latest/docs/api/http.html#http_server_keepalivetimeout)).                   | NO       | Node.js default (5 seconds)                                                                           |
-| `removeSensitiveData`        | Boolean attribute. When set to "false", Adyen fields with additional information about the payment will be saved in the interface interaction and in the custom fields.         | NO       | true                                                                                                  |
+| Name                         | Content                                                                                                                                                                                                      | Default value                                                                                         |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `adyenPaymentMethodsToNames` | Key-value object where key is `paymentMethod` returned in the notification and value is the custom localized name that will be saved in CTP `payment.paymentMethodInfo.method`.                              | `{scheme: {en: 'Credit Card'}, pp: {en: 'PayPal'}, klarna: {en: 'Klarna'}, gpay: {en: 'Google Pay'}}` |
+| `port`                       | The port number on which the application will run.                                                                                                                                                           | 443                                                                                                   |
+| `logLevel`                   | The log level (`trace`, `debug`, `info`, `warn`, `error`, `fatal`).                                                                                                                                          | `info`                                                                                                |
+| `keepAliveTimeout`           | Milliseconds to keep a socket alive after the last response ([Node.js docs](https://nodejs.org/dist/latest/docs/api/http.html#http_server_keepalivetimeout)).                                                | Node.js default (5 seconds)                                                                           |
+| `removeSensitiveData`        | Boolean attribute. When set to "false", Adyen fields with additional information about the payment will be saved in the interface interaction and in the custom fields.                                      | true                                                                                                  |
+| `notificationBaseUrl`        | Publicly available URL of the Notification module. In case of any payment changes, Adyen will call this URL and pass the notification in body. This attribute is used when calling `npm run setup-resources` |                                                                                                       |
+| `apiKey`                     | This key will be used to make authenticated API requests to Adyen. This attribute is used when calling `npm run setup-resources`                                                                             |                                                                                                       |
 
 ### External file configuration
 
@@ -117,7 +119,7 @@ Resources below are required for the notification module to operate correctly.
 
 1. [Payment-interface-interaction custom type](../resources/payment-interface-interaction-type.json)
 
-You can create these by running the command `npm run setup-resources` as below, the command requires the `ADYEN_INTEGRATION_CONFIG` to be set as an environment variable.
+You can create these by running the command `npm run setup-resources` as below, the command requires the `ADYEN_INTEGRATION_CONFIG` to be set as an environment variable. Be aware that this command also sets up [the notification webhook in Adyen](./IntegrationGuide.md#step-1-set-up-notification-webhook-and-generate-hmac-signature).
 
 ```bash
 export ADYEN_INTEGRATION_CONFIG=xxxx

--- a/notification/docs/IntegrationGuide.md
+++ b/notification/docs/IntegrationGuide.md
@@ -23,7 +23,14 @@ The following diagram shows the integration flow of the notification module base
 You have to register the Notification module `public URL` in the Adyen Customer Area in order to receive notifications.
 To protect your server from unauthorized notifications, we strongly recommend that you activate Hash-based message authentication code (HMAC) signatures during the setup.
 
-Please follow the [instructions](https://docs.adyen.com/development-resources/webhooks#set-up-notifications-in-your-customer-area) described by Adyen to set up notifications in your live Customer Area.
+You can set up the webhooks and generate HMAC by running the command `npm run setup-resources` as below, the command requires the `ADYEN_INTEGRATION_CONFIG` to be set as an environment variable. Be aware that this command also sets up [the commercetools resources required for the notification module](./HowToRun.md#commercetools-project-requirements).
+
+```bash
+export ADYEN_INTEGRATION_CONFIG=xxxx
+npm run setup-resources
+```
+
+If you want to do the setup manually, please follow the [instructions](https://docs.adyen.com/development-resources/webhooks#set-up-notifications-in-your-customer-area) described by Adyen to set up notifications in your live Customer Area.
 
 > Note: HMAC verification is enabled by default. You could use "ADYEN_ENABLE_HMAC_SIGNATURE=false" environment variable to disable the verification feature.
 

--- a/notification/src/config/config.js
+++ b/notification/src/config/config.js
@@ -9,6 +9,7 @@ function getModuleConfig() {
   if (config.removeSensitiveData === false) removeSensitiveData = false
   return {
     removeSensitiveData,
+    notificationBaseUrl: config.notificationBaseUrl,
     port: config.port,
     logLevel: config.logLevel,
     keepAliveTimeout: !Number.isNaN(config.keepAliveTimeout)

--- a/notification/src/config/config.js
+++ b/notification/src/config/config.js
@@ -9,7 +9,6 @@ function getModuleConfig() {
   if (config.removeSensitiveData === false) removeSensitiveData = false
   return {
     removeSensitiveData,
-    notificationBaseUrl: config.notificationBaseUrl,
     port: config.port,
     logLevel: config.logLevel,
     keepAliveTimeout: !Number.isNaN(config.keepAliveTimeout)
@@ -50,8 +49,9 @@ function getAdyenConfig(adyenMerchantAccount) {
   if (adyenConfig.enableHmacSignature === false) enableHmacSignature = false
   return {
     secretHmacKey: adyenConfig.secretHmacKey,
+    notificationBaseUrl: adyenConfig.notificationBaseUrl,
     enableHmacSignature,
-    apiKey: adyenConfig.apiKey
+    apiKey: adyenConfig.apiKey,
   }
 }
 

--- a/notification/src/config/config.js
+++ b/notification/src/config/config.js
@@ -50,6 +50,7 @@ function getAdyenConfig(adyenMerchantAccount) {
   return {
     secretHmacKey: adyenConfig.secretHmacKey,
     enableHmacSignature,
+    apiKey: adyenConfig.apiKey
   }
 }
 

--- a/notification/src/config/init/ensure-adyen-webhook.js
+++ b/notification/src/config/init/ensure-adyen-webhook.js
@@ -29,9 +29,9 @@ async function ensureAdyenWebhook(adyenApiKey, webhookUrl, merchantId) {
         },
       }
     )
-    const getWebhookResponseResponseJson = await getWebhookResponse.json()
+    const getWebhookResponseJson = await getWebhookResponse.json()
 
-    const existingWebhook = getWebhookResponseResponseJson.data?.find(
+    const existingWebhook = getWebhookResponseJson.data?.find(
       (webhook) =>
         webhook.url === webhookConfig.url && webhook.type === webhookConfig.type
     )

--- a/notification/src/config/init/ensure-adyen-webhook.js
+++ b/notification/src/config/init/ensure-adyen-webhook.js
@@ -1,73 +1,99 @@
 import fetch from 'node-fetch'
-import {getLogger} from "../../utils/logger.js"
-import config from "../config.js";
+import { serializeError } from 'serialize-error'
+import { getLogger } from '../../utils/logger.js'
+import config from '../config.js'
 
 const mainLogger = getLogger()
 
 async function ensureAdyenWebhook(adyenApiKey, webhookUrl, merchantId) {
-  const webhookConfig = {
-    "type": "standard",
-    "url": webhookUrl,
-    "active": "true",
-    "communicationFormat": "json",
-    "description": "commercetools-adyen-integration notification webhook"
-  }
+  try {
+    const logger = mainLogger.child({
+      adyen_merchant_id: merchantId,
+    })
 
-  const getWebhookResponse = await fetch(`https://management-test.adyen.com/v1/merchants/${merchantId}/webhooks`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Api-Key': adyenApiKey
-    },
-  })
-  const getWebhookResponseResponseJson = await getWebhookResponse.json()
-
-  const existingWebhook = getWebhookResponseResponseJson.data
-    .find(webhook => webhook.url === webhookConfig.url && webhook.type === webhookConfig.type)
-
-  if (existingWebhook) {
-    mainLogger.info(`Webhook already existed with ID ${existingWebhook.id}`)
-    return
-  }
-
-  const createWebhookResponse = await fetch(`https://management-test.adyen.com/v1/merchants/${merchantId}/webhooks`, {
-    body: JSON.stringify(webhookConfig),
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Api-Key': adyenApiKey
+    const webhookConfig = {
+      type: 'standard',
+      url: webhookUrl,
+      active: 'true',
+      communicationFormat: 'json',
+      description: 'commercetools-adyen-integration notification webhook',
     }
-  })
 
-  const createWebhookResponseJson = await createWebhookResponse.json()
-  const webhookId = createWebhookResponseJson.id
+    const getWebhookResponse = await fetch(
+      `https://management-test.adyen.com/v1/merchants/${merchantId}/webhooks`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Api-Key': adyenApiKey,
+        },
+      }
+    )
+    const getWebhookResponseResponseJson = await getWebhookResponse.json()
 
-  mainLogger.info(`New webhook was created with ID ${webhookId}`)
+    const existingWebhook = getWebhookResponseResponseJson.data?.find(
+      (webhook) =>
+        webhook.url === webhookConfig.url && webhook.type === webhookConfig.type
+    )
 
-  const generateHmacResponse = await fetch(
-    `https://management-test.adyen.com/v1/merchants/${merchantId}/webhooks/${webhookId}/generateHmac`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Api-Key': adyenApiKey
-    },
-  })
+    if (existingWebhook) {
+      logger.info(
+        `Webhook already existed with ID ${existingWebhook.id}. Skipping webhook creation...`
+      )
+      return
+    }
 
-  const generateHmacResponseJson = await generateHmacResponse.json()
-  const { hmacKey } = generateHmacResponseJson
+    const createWebhookResponse = await fetch(
+      `https://management-test.adyen.com/v1/merchants/${merchantId}/webhooks`,
+      {
+        body: JSON.stringify(webhookConfig),
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Api-Key': adyenApiKey,
+        },
+      }
+    )
 
-  mainLogger.info(`HMAC key generated ${hmacKey}`)
+    const createWebhookResponseJson = await createWebhookResponse.json()
+    const webhookId = createWebhookResponseJson.id
+
+    logger.info(`New webhook was created with ID ${webhookId}`)
+  } catch (err) {
+    throw Error(
+      `Failed to ensure adyen webhook for project ${merchantId}.` +
+        `Error: ${JSON.stringify(serializeError(err))}`
+    )
+  }
+
+  // todo: will be done later
+  // const generateHmacResponse = await fetch(
+  //   `https://management-test.adyen.com/v1/merchants/${merchantId}/webhooks/${webhookId}/generateHmac`, {
+  //   method: 'POST',
+  //   headers: {
+  //     'Content-Type': 'application/json',
+  //     'X-Api-Key': adyenApiKey
+  //   },
+  // })
+  //
+  // const generateHmacResponseJson = await generateHmacResponse.json()
+  // const { hmacKey } = generateHmacResponseJson
+  //
+  // logger.info(`HMAC key generated ${hmacKey}`)
 }
 
 async function ensureAdyenWebhooksForAllProjects() {
   const adyenMerchantAccounts = config.getAllAdyenMerchantAccounts()
   for (const adyenMerchantId of adyenMerchantAccounts) {
     const adyenConfig = config.getAdyenConfig(adyenMerchantId)
-    await ensureAdyenWebhook(adyenConfig.apiKey, adyenConfig.notificationBaseUrl, adyenMerchantId)
+    if (adyenConfig.notificationBaseUrl) {
+      await ensureAdyenWebhook(
+        adyenConfig.apiKey,
+        adyenConfig.notificationBaseUrl,
+        adyenMerchantId
+      )
+    }
   }
 }
 
-
-export {
-  ensureAdyenWebhooksForAllProjects
-}
+export { ensureAdyenWebhooksForAllProjects }

--- a/notification/src/config/init/ensure-adyen-webhook.js
+++ b/notification/src/config/init/ensure-adyen-webhook.js
@@ -1,0 +1,65 @@
+import fetch from 'node-fetch'
+import {getLogger} from "../../utils/logger.js"
+import config from '../../config/config.js'
+
+const mainLogger = getLogger()
+
+async function ensureAdyenWebhook(adyenApiKey, webhookUrl, merchantId) {
+  const webhookConfig = {
+    "type": "standard",
+    "url": webhookUrl,
+    "active": "true",
+    "communicationFormat": "json",
+    "description": "commercetools-adyen-integration notification webhook"
+  }
+
+  const getWebhookResponse = await fetch(`https://management-test.adyen.com/v1/merchants/${merchantId}/webhooks`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Api-Key': adyenApiKey
+    },
+  })
+  const getWebhookResponseResponseJson = await getWebhookResponse.json()
+
+  const existingWebhook = getWebhookResponseResponseJson.data
+    .find(webhook => webhook.url === webhookConfig.url && webhook.type === webhookConfig.type)
+
+  if (existingWebhook) {
+    mainLogger.info(`Webhook already existed with ID ${existingWebhook.id}`)
+    return
+  }
+
+  const createWebhookResponse = await fetch(`https://management-test.adyen.com/v1/merchants/${merchantId}/webhooks`, {
+    body: JSON.stringify(webhookConfig),
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Api-Key': adyenApiKey
+    }
+  })
+
+  const createWebhookResponseJson = await createWebhookResponse.json()
+  const webhookId = createWebhookResponseJson.id
+
+  mainLogger.info(`New webhook was created with ID ${webhookId}`)
+
+  const generateHmacResponse = await fetch(`https://management-test.adyen.com/v1/merchants/${merchantId}/webhooks/${webhookId}/generateHmac`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Api-Key': adyenApiKey
+    },
+  })
+
+  const generateHmacResponseJson = await generateHmacResponse.json()
+  const hmacKey = generateHmacResponseJson.hmacKey
+
+  mainLogger.info(`HMAC key generated ${hmacKey}`)
+}
+
+await ensureAdyenWebhook(
+  config.getAdyenConfig(config.getAllAdyenMerchantAccounts()[1]).apiKey,
+  'https://fea7-94-142-239-39.ngrok.io',
+  config.getAllAdyenMerchantAccounts()[1]
+)

--- a/notification/src/config/init/ensure-adyen-webhook.js
+++ b/notification/src/config/init/ensure-adyen-webhook.js
@@ -1,6 +1,6 @@
 import fetch from 'node-fetch'
 import {getLogger} from "../../utils/logger.js"
-import config from '../../config/config.js'
+import config from "../config.js";
 
 const mainLogger = getLogger()
 
@@ -44,7 +44,8 @@ async function ensureAdyenWebhook(adyenApiKey, webhookUrl, merchantId) {
 
   mainLogger.info(`New webhook was created with ID ${webhookId}`)
 
-  const generateHmacResponse = await fetch(`https://management-test.adyen.com/v1/merchants/${merchantId}/webhooks/${webhookId}/generateHmac`, {
+  const generateHmacResponse = await fetch(
+    `https://management-test.adyen.com/v1/merchants/${merchantId}/webhooks/${webhookId}/generateHmac`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -53,13 +54,20 @@ async function ensureAdyenWebhook(adyenApiKey, webhookUrl, merchantId) {
   })
 
   const generateHmacResponseJson = await generateHmacResponse.json()
-  const hmacKey = generateHmacResponseJson.hmacKey
+  const { hmacKey } = generateHmacResponseJson
 
   mainLogger.info(`HMAC key generated ${hmacKey}`)
 }
 
-await ensureAdyenWebhook(
-  config.getAdyenConfig(config.getAllAdyenMerchantAccounts()[1]).apiKey,
-  'https://fea7-94-142-239-39.ngrok.io',
-  config.getAllAdyenMerchantAccounts()[1]
-)
+async function ensureAdyenWebhooksForAllProjects() {
+  const adyenMerchantAccounts = config.getAllAdyenMerchantAccounts()
+  for (const adyenMerchantId of adyenMerchantAccounts) {
+    const adyenConfig = config.getAdyenConfig(adyenMerchantId)
+    await ensureAdyenWebhook(adyenConfig.apiKey, adyenConfig.notificationBaseUrl, adyenMerchantId)
+  }
+}
+
+
+export {
+  ensureAdyenWebhooksForAllProjects
+}

--- a/notification/src/setup.js
+++ b/notification/src/setup.js
@@ -1,11 +1,13 @@
 import config from './config/config.js'
 import { getLogger } from './utils/logger.js'
-// eslint-disable-next-line max-len
-import { ensureInterfaceInteractionCustomTypeForAllProjects } from './config/init/ensure-interface-interaction-custom-type.js'
+import { ensureInterfaceInteractionCustomTypeForAllProjects }
+  from './config/init/ensure-interface-interaction-custom-type.js'
+import { ensureAdyenWebhooksForAllProjects } from "./config/init/ensure-adyen-webhook.js"
 
 const logger = getLogger()
 
 async function setupNotificationResources() {
+  await ensureAdyenWebhooksForAllProjects()
   await ensureInterfaceInteractionCustomTypeForAllProjects()
 
   const ctpProjectKeys = config.getAllCtpProjectKeys()

--- a/notification/src/setup.js
+++ b/notification/src/setup.js
@@ -1,8 +1,8 @@
 import config from './config/config.js'
 import { getLogger } from './utils/logger.js'
-import { ensureInterfaceInteractionCustomTypeForAllProjects }
-  from './config/init/ensure-interface-interaction-custom-type.js'
-import { ensureAdyenWebhooksForAllProjects } from "./config/init/ensure-adyen-webhook.js"
+// eslint-disable-next-line max-len
+import { ensureInterfaceInteractionCustomTypeForAllProjects } from './config/init/ensure-interface-interaction-custom-type.js'
+import { ensureAdyenWebhooksForAllProjects } from './config/init/ensure-adyen-webhook.js'
 
 const logger = getLogger()
 

--- a/notification/test/unit/config.spec.js
+++ b/notification/test/unit/config.spec.js
@@ -194,6 +194,8 @@ describe('::config::', () => {
         ).to.deep.equal({
           enableHmacSignature: false,
           secretHmacKey: undefined,
+          notificationBaseUrl: undefined,
+          apiKey: undefined,
         })
       } finally {
         fs.unlinkSync(filePath)


### PR DESCRIPTION
This PR adds an ensure functionality for adyen webhooks.

HMAC is not added yet in this PR. It will be done in the next PR.

The part `ensuring fallback for metadata` is not possible with this feature. The reason is there is no specified connection between the Adyen project and CTP project and thus the URL cannot be ensured automatically. The correct fallback URL must be created by the user.