### PR TITLE
Fix notification payment lookup

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -50,7 +50,7 @@ If you accidentally created a subscription you can edit it and uncheck the **Act
 
 ### How does the notification module find a matching payment?
 
-It first find the payment by `key` where `key=${merchantReference}` and then it finds in this payment the corresponding transaction by `interactionId` where `interactionId=${pspReference}`.
+It first find the payment by `key` where `key in (${merchantReference}, ${pspReference})`. If original reference exists in notification, the payment can be found by `key` where `key in (${merchantReference}, ${originalReference})`. And then it finds in this payment the corresponding transaction by `interactionId` where `interactionId=${pspReference}`.
 
 ### Will we lose a notification if it was not processed for some reason?
 

--- a/docs/adr/0002-matching-adyen-notification.md
+++ b/docs/adr/0002-matching-adyen-notification.md
@@ -25,3 +25,32 @@ by `interactionId` where `interactionId=${pspReference}`.
 - It is easier to fetch a key rather than using a custom field, also a key is an indexed field, so with a key, it's more performant.
 - The payment key is unique for all payments.
 - It's not possible to set key with my-payments endpoint. This prevents by default changing/removing the key accidentally. It is more secure than custom fields as the custom field might be changed with my-payment endpoint. Check for more details: https://docs.commercetools.com/api/projects/me-payments
+
+
+Date: 2023-01-03
+
+## Status
+
+[Accepted](https://github.com/commercetools/commercetools-adyen-integration/pull/1049)
+
+## Context
+
+The Adyen notification needs to be matched by its commercetools payment equivalent.
+We are using the payment key for the merchantReference and fetching the commercetools payment object with query `key="${merchantReference}"`.
+Since we have introduced custom reference for refund 
+in [v9.10.0](https://github.com/commercetools/commercetools-adyen-integration/releases/tag/v9.10.0), payment is no long able to be obtained by merchant reference as key. 
+
+The alternative for that is the native payment `key` field.
+
+## Decision
+
+- We will use both `pspReference` and `merchantReference` as payment key for matching payment for notification.
+- `merchantReference` is still used for payment lookup because `pspReference` is obtained in notification module instead of extension module in Adyen Web Component version 5.0.
+- For events other than AUTHORIZATION, such as REFUND, CAPTURE, CANCEL, we use `originalReference` from notification
+- The notification will use the native payment key to fetch payment. It first finds the payment by `key` where `key in (${merchantReference}, ${pspReference})`.
+(If `originalReference` exists, find the payment by `key` where `key in (${merchantReference}, ${originalReference})`), and then it finds in this payment the corresponding transaction by `interactionId` where `interactionId=${pspReference}`. 
+
+## Consequences
+
+- It is possible to lookup payment for different transaction throughout the whole payment process
+- The payment key with `pspReference` (or `originalReference) is also unique for all payments.

--- a/docs/adr/0002-matching-adyen-notification.md
+++ b/docs/adr/0002-matching-adyen-notification.md
@@ -4,7 +4,7 @@ Date: 2020-12-18
 
 ## Status
 
-[Accepted](https://github.com/commercetools/commercetools-adyen-integration/pull/395)
+[Deprecated](https://github.com/commercetools/commercetools-adyen-integration/pull/395)
 
 ## Context
 
@@ -26,31 +26,4 @@ by `interactionId` where `interactionId=${pspReference}`.
 - The payment key is unique for all payments.
 - It's not possible to set key with my-payments endpoint. This prevents by default changing/removing the key accidentally. It is more secure than custom fields as the custom field might be changed with my-payment endpoint. Check for more details: https://docs.commercetools.com/api/projects/me-payments
 
-
-Date: 2023-01-03
-
-## Status
-
-[Accepted](https://github.com/commercetools/commercetools-adyen-integration/pull/1049)
-
-## Context
-
-The Adyen notification needs to be matched by its commercetools payment equivalent.
-We are using the payment key for the merchantReference and fetching the commercetools payment object with query `key="${merchantReference}"`.
-Since we have introduced custom reference for refund 
-in [v9.10.0](https://github.com/commercetools/commercetools-adyen-integration/releases/tag/v9.10.0), payment is no long able to be obtained by merchant reference as key. 
-
-The alternative for that is the native payment `key` field.
-
-## Decision
-
-- We will use both `pspReference` and `merchantReference` as payment key for matching payment for notification.
-- `merchantReference` is still used for payment lookup because `pspReference` is obtained in notification module instead of extension module in Adyen Web Component version 5.0.
-- For events other than AUTHORIZATION, such as REFUND, CAPTURE, CANCEL, we use `originalReference` from notification
-- The notification will use the native payment key to fetch payment. It first finds the payment by `key` where `key in (${merchantReference}, ${pspReference})`.
-(If `originalReference` exists, find the payment by `key` where `key in (${merchantReference}, ${originalReference})`), and then it finds in this payment the corresponding transaction by `interactionId` where `interactionId=${pspReference}`. 
-
-## Consequences
-
-- It is possible to lookup payment for different transaction throughout the whole payment process
-- The payment key with `pspReference` (or `originalReference) is also unique for all payments.
+Please refer to the [0011-matching-adyen-notification](./0011-matching-adyen-notification.md) for the latest change regarding matching Notification with payment.

--- a/docs/adr/0011-matching-adyen-notification.md
+++ b/docs/adr/0011-matching-adyen-notification.md
@@ -20,11 +20,11 @@ The alternative for that is to use `pspReference` as payment `key` field.
 - We will use either `pspReference` or `merchantReference` as payment key for matching payment for notification.
 - For web component version 5, `pspReference` is first provided in notification with AUTHORIZATION event. It is different from web component version 4, in which `pspReference` has already been provided from Adyen API response in extension module, and used to update as payment key. Therefore we still need `merchantReference` for payment lookup in this scenario.
 Once payment can be matched, update the payment key with `pspReference` obtained in notification.
-- For events other than AUTHORIZATION, such as REFUND, CAPTURE, CANCEL, we use `originalReference` from notification
-- The notification will use the native payment key to fetch payment. It first finds the payment by `key` where `key in (${merchantReference}, ${pspReference})`.
-(If `originalReference` exists, find the payment by `key` where `key in (${merchantReference}, ${originalReference})`), and then it finds in this payment the corresponding transaction by `interactionId` where `interactionId=${pspReference}`. 
+- For events other than AUTHORIZATION, such as REFUND, CAPTURE, CANCEL, we use `originalReference` from notification, which is the original `pspReference` obtained in AUTHORIZATION notification.
+- The notification will use the CTP payment key to fetch payment. It first check if `originalReference` exists. If yes, 
+  it finds the payment by `key` where `key in (${merchantReference}, ${originalReference})`), otherwise it finds the payment by `key` where `key in (${merchantReference}, ${pspReference})`.
+  After that it finds the corresponding transaction in this payment by `interactionId` where `interactionId=${pspReference}`. 
 
 ## Consequences
-
 - It is possible to lookup payment for different transaction throughout the whole payment process
 - The payment key with `pspReference` (or `originalReference`) is also unique for all payments.

--- a/docs/adr/0011-matching-adyen-notification.md
+++ b/docs/adr/0011-matching-adyen-notification.md
@@ -20,7 +20,7 @@ The alternative for that is to use `pspReference` as payment `key` field.
 - We will use `originalReference` (or `pspReference` if `originalReference` does not exist) or `merchantReference` as payment key for matching payment for notification.
 - For web component version 4, `pspReference` can be obtained from `makePaymentResponse` in extension module. It is used to update as payment key. Therefore we can match the payment by `pspReference` given in notification.
 - For web component version 5, `pspReference` is first provided in notification with AUTHORIZATION event. It is different from web component version 4, in which `pspReference` has already been provided from Adyen API response in extension module, and used to update as payment key. Therefore we still need `merchantReference` for payment lookup in this scenario.
-Once payment can be matched, update the payment key with `pspReference` obtained in notification.
+Once payment is found, update the payment key with `pspReference` obtained in notification.
 - For events other than AUTHORIZATION, such as REFUND, CAPTURE, CANCEL, we use `originalReference` from notification, which is the original `pspReference` obtained in AUTHORIZATION notification.
 - The notification will use the CTP payment key to fetch payment. It first check if `originalReference` exists. If yes, 
   it finds the payment by `key` where `key in (${merchantReference}, ${originalReference})`), otherwise it finds the payment by `key` where `key in (${merchantReference}, ${pspReference})`.

--- a/docs/adr/0011-matching-adyen-notification.md
+++ b/docs/adr/0011-matching-adyen-notification.md
@@ -17,7 +17,7 @@ The alternative for that is the native payment `key` field.
 
 ## Decision
 
-- We will use both `pspReference` and `merchantReference` as payment key for matching payment for notification.
+- We will use either `pspReference` or `merchantReference` as payment key for matching payment for notification.
 - `merchantReference` is still used for payment lookup because `pspReference` is obtained in notification module instead of extension module in Adyen Web Component version 5.0.
 - For events other than AUTHORIZATION, such as REFUND, CAPTURE, CANCEL, we use `originalReference` from notification
 - The notification will use the native payment key to fetch payment. It first finds the payment by `key` where `key in (${merchantReference}, ${pspReference})`.

--- a/docs/adr/0011-matching-adyen-notification.md
+++ b/docs/adr/0011-matching-adyen-notification.md
@@ -18,16 +18,13 @@ The alternative for that is to use `pspReference` as payment `key` field.
 ## Decision
 
 - We will use `originalReference` (or `pspReference` if `originalReference` does not exist) or `merchantReference` as payment key for matching payment for notification.
-- For web component version 4, `pspReference` can be obtained from `makePaymentResponse` in extension module. It is used to update as payment key. Therefore we can match the payment by `pspReference` given in notification.
 - For web component version 5, `pspReference` is first provided in notification with AUTHORIZATION event. It is different from web component version 4, in which `pspReference` has already been provided from Adyen API response in extension module, and used to update as payment key. Therefore we still need `merchantReference` for payment lookup in this scenario.
 Once payment can be matched, update the payment key with `pspReference` obtained in notification.
 - For events other than AUTHORIZATION, such as REFUND, CAPTURE, CANCEL, we use `originalReference` from notification, which is the original `pspReference` obtained in AUTHORIZATION notification.
 - The notification will use the CTP payment key to fetch payment. It first check if `originalReference` exists. If yes, 
   it finds the payment by `key` where `key in (${merchantReference}, ${originalReference})`), otherwise it finds the payment by `key` where `key in (${merchantReference}, ${pspReference})`.
   After that it finds the corresponding transaction in this payment by `interactionId` where `interactionId=${pspReference}`. 
-  
-  For details, please refer to the [code snippet](https://github.com/commercetools/commercetools-adyen-integration/blob/master/notification/src/handler/notification/notification.handler.js#L52)
-  
+
 ## Consequences
 - It is possible to lookup payment for different transaction throughout the whole payment process
 - The payment key with `pspReference` (or `originalReference`) is also unique for all payments.

--- a/docs/adr/0011-matching-adyen-notification.md
+++ b/docs/adr/0011-matching-adyen-notification.md
@@ -9,9 +9,9 @@ Date: 2023-01-03
 ## Context
 
 The Adyen notification needs to be matched by its commercetools payment equivalent.
-We are using the payment key for the merchantReference and fetching the commercetools payment object with query `key="${merchantReference}"`.
-Since we have introduced custom reference for refund 
-in [v9.10.0](https://github.com/commercetools/commercetools-adyen-integration/releases/tag/v9.10.0), payment is no long able to be obtained by merchant reference as key. 
+We are using the payment key for the `merchantReference` and fetching the commercetools payment object with query `key="${merchantReference}"`.
+Since [v9.10.0](https://github.com/commercetools/commercetools-adyen-integration/releases/tag/v9.10.0), we have introduced custom reference for refund.
+Payment key could be the custom field in payment transaction defined by user, therefore payment is no longer always able to be obtained by merchant reference as key. 
 
 The alternative for that is to use `pspReference` as payment `key` field.
 

--- a/docs/adr/0011-matching-adyen-notification.md
+++ b/docs/adr/0011-matching-adyen-notification.md
@@ -18,13 +18,16 @@ The alternative for that is to use `pspReference` as payment `key` field.
 ## Decision
 
 - We will use `originalReference` (or `pspReference` if `originalReference` does not exist) or `merchantReference` as payment key for matching payment for notification.
+- For web component version 4, `pspReference` can be obtained from `makePaymentResponse` in extension module. It is used to update as payment key. Therefore we can match the payment by `pspReference` given in notification.
 - For web component version 5, `pspReference` is first provided in notification with AUTHORIZATION event. It is different from web component version 4, in which `pspReference` has already been provided from Adyen API response in extension module, and used to update as payment key. Therefore we still need `merchantReference` for payment lookup in this scenario.
 Once payment can be matched, update the payment key with `pspReference` obtained in notification.
 - For events other than AUTHORIZATION, such as REFUND, CAPTURE, CANCEL, we use `originalReference` from notification, which is the original `pspReference` obtained in AUTHORIZATION notification.
 - The notification will use the CTP payment key to fetch payment. It first check if `originalReference` exists. If yes, 
   it finds the payment by `key` where `key in (${merchantReference}, ${originalReference})`), otherwise it finds the payment by `key` where `key in (${merchantReference}, ${pspReference})`.
   After that it finds the corresponding transaction in this payment by `interactionId` where `interactionId=${pspReference}`. 
-
+  
+  For details, please refer to the [code snippet](https://github.com/commercetools/commercetools-adyen-integration/blob/master/notification/src/handler/notification/notification.handler.js#L52)
+  
 ## Consequences
 - It is possible to lookup payment for different transaction throughout the whole payment process
 - The payment key with `pspReference` (or `originalReference`) is also unique for all payments.

--- a/docs/adr/0011-matching-adyen-notification.md
+++ b/docs/adr/0011-matching-adyen-notification.md
@@ -17,7 +17,7 @@ The alternative for that is to use `pspReference` as payment `key` field.
 
 ## Decision
 
-- We will use either `pspReference` or `merchantReference` as payment key for matching payment for notification.
+- We will use `originalReference` (or `pspReference` if `originalReference` does not exist) or `merchantReference` as payment key for matching payment for notification.
 - For web component version 5, `pspReference` is first provided in notification with AUTHORIZATION event. It is different from web component version 4, in which `pspReference` has already been provided from Adyen API response in extension module, and used to update as payment key. Therefore we still need `merchantReference` for payment lookup in this scenario.
 Once payment can be matched, update the payment key with `pspReference` obtained in notification.
 - For events other than AUTHORIZATION, such as REFUND, CAPTURE, CANCEL, we use `originalReference` from notification, which is the original `pspReference` obtained in AUTHORIZATION notification.

--- a/docs/adr/0011-matching-adyen-notification.md
+++ b/docs/adr/0011-matching-adyen-notification.md
@@ -18,12 +18,15 @@ The alternative for that is to use `pspReference` as payment `key` field.
 ## Decision
 
 - We will use `originalReference` (or `pspReference` if `originalReference` does not exist) or `merchantReference` as payment key for matching payment for notification.
+- For web component version 4, `pspReference` can be obtained from `makePaymentResponse` in extension module. It is used to update as payment key. Therefore we can match the payment by `pspReference` given in notification.
 - For web component version 5, `pspReference` is first provided in notification with AUTHORIZATION event. It is different from web component version 4, in which `pspReference` has already been provided from Adyen API response in extension module, and used to update as payment key. Therefore we still need `merchantReference` for payment lookup in this scenario.
 Once payment can be matched, update the payment key with `pspReference` obtained in notification.
 - For events other than AUTHORIZATION, such as REFUND, CAPTURE, CANCEL, we use `originalReference` from notification, which is the original `pspReference` obtained in AUTHORIZATION notification.
 - The notification will use the CTP payment key to fetch payment. It first check if `originalReference` exists. If yes, 
   it finds the payment by `key` where `key in (${merchantReference}, ${originalReference})`), otherwise it finds the payment by `key` where `key in (${merchantReference}, ${pspReference})`.
   After that it finds the corresponding transaction in this payment by `interactionId` where `interactionId=${pspReference}`. 
+
+For details, please refer to the [code snippet](https://github.com/commercetools/commercetools-adyen-integration/blob/dcbc5794cd4c470d1cf5a8c23623214671bf1849/notification/src/handler/notification/notification.handler.js#L52)
 
 ## Consequences
 - It is possible to lookup payment for different transaction throughout the whole payment process

--- a/docs/adr/0011-matching-adyen-notification.md
+++ b/docs/adr/0011-matching-adyen-notification.md
@@ -27,4 +27,4 @@ Once payment can be matched, update the payment key with `pspReference` obtained
 ## Consequences
 
 - It is possible to lookup payment for different transaction throughout the whole payment process
-- The payment key with `pspReference` (or `originalReference) is also unique for all payments.
+- The payment key with `pspReference` (or `originalReference`) is also unique for all payments.

--- a/docs/adr/0011-matching-adyen-notification.md
+++ b/docs/adr/0011-matching-adyen-notification.md
@@ -19,6 +19,7 @@ The alternative for that is to use `pspReference` as payment `key` field.
 
 - We will use either `pspReference` or `merchantReference` as payment key for matching payment for notification.
 - For web component version 5, `pspReference` is first provided in notification with AUTHORIZATION event. It is different from web component version 4, in which `pspReference` has already been provided from Adyen API response in extension module, and used to update as payment key. Therefore we still need `merchantReference` for payment lookup in this scenario.
+Once payment can be matched, update the payment key with `pspReference` obtained in notification.
 - For events other than AUTHORIZATION, such as REFUND, CAPTURE, CANCEL, we use `originalReference` from notification
 - The notification will use the native payment key to fetch payment. It first finds the payment by `key` where `key in (${merchantReference}, ${pspReference})`.
 (If `originalReference` exists, find the payment by `key` where `key in (${merchantReference}, ${originalReference})`), and then it finds in this payment the corresponding transaction by `interactionId` where `interactionId=${pspReference}`. 

--- a/docs/adr/0011-matching-adyen-notification.md
+++ b/docs/adr/0011-matching-adyen-notification.md
@@ -13,7 +13,7 @@ We are using the payment key for the merchantReference and fetching the commerce
 Since we have introduced custom reference for refund 
 in [v9.10.0](https://github.com/commercetools/commercetools-adyen-integration/releases/tag/v9.10.0), payment is no long able to be obtained by merchant reference as key. 
 
-The alternative for that is the native payment `key` field.
+The alternative for that is to use `pspReference` as payment `key` field.
 
 ## Decision
 

--- a/docs/adr/0011-matching-adyen-notification.md
+++ b/docs/adr/0011-matching-adyen-notification.md
@@ -18,7 +18,7 @@ The alternative for that is the native payment `key` field.
 ## Decision
 
 - We will use either `pspReference` or `merchantReference` as payment key for matching payment for notification.
-- `merchantReference` is still used for payment lookup because `pspReference` is obtained in notification module instead of extension module in Adyen Web Component version 5.0.
+- For web component version 5, `pspReference` is first provided in notification with AUTHORIZATION event. It is different from web component version 4, in which `pspReference` has already been provided from Adyen API response in extension module, and used to update as payment key. Therefore we still need `merchantReference` for payment lookup in this scenario.
 - For events other than AUTHORIZATION, such as REFUND, CAPTURE, CANCEL, we use `originalReference` from notification
 - The notification will use the native payment key to fetch payment. It first finds the payment by `key` where `key in (${merchantReference}, ${pspReference})`.
 (If `originalReference` exists, find the payment by `key` where `key in (${merchantReference}, ${originalReference})`), and then it finds in this payment the corresponding transaction by `interactionId` where `interactionId=${pspReference}`. 

--- a/docs/adr/0011-matching-adyen-notification.md
+++ b/docs/adr/0011-matching-adyen-notification.md
@@ -1,0 +1,29 @@
+# 11. Matching Adyen Notification with commercetools payment.
+
+Date: 2023-01-03
+
+## Status
+
+[Accepted](https://github.com/commercetools/commercetools-adyen-integration/pull/1049)
+
+## Context
+
+The Adyen notification needs to be matched by its commercetools payment equivalent.
+We are using the payment key for the merchantReference and fetching the commercetools payment object with query `key="${merchantReference}"`.
+Since we have introduced custom reference for refund 
+in [v9.10.0](https://github.com/commercetools/commercetools-adyen-integration/releases/tag/v9.10.0), payment is no long able to be obtained by merchant reference as key. 
+
+The alternative for that is the native payment `key` field.
+
+## Decision
+
+- We will use both `pspReference` and `merchantReference` as payment key for matching payment for notification.
+- `merchantReference` is still used for payment lookup because `pspReference` is obtained in notification module instead of extension module in Adyen Web Component version 5.0.
+- For events other than AUTHORIZATION, such as REFUND, CAPTURE, CANCEL, we use `originalReference` from notification
+- The notification will use the native payment key to fetch payment. It first finds the payment by `key` where `key in (${merchantReference}, ${pspReference})`.
+(If `originalReference` exists, find the payment by `key` where `key in (${merchantReference}, ${originalReference})`), and then it finds in this payment the corresponding transaction by `interactionId` where `interactionId=${pspReference}`. 
+
+## Consequences
+
+- It is possible to lookup payment for different transaction throughout the whole payment process
+- The payment key with `pspReference` (or `originalReference) is also unique for all payments.

--- a/extension/src/paymentHandler/make-payment.handler.js
+++ b/extension/src/paymentHandler/make-payment.handler.js
@@ -43,8 +43,8 @@ async function execute(paymentObject) {
 
   const updatePaymentAction = getPaymentKeyUpdateAction(
     paymentObject.key,
-    adyenRequest,
-    adyenResponse
+    request,
+    response
   )
   if (updatePaymentAction) actions.push(updatePaymentAction)
 

--- a/extension/src/paymentHandler/make-payment.handler.js
+++ b/extension/src/paymentHandler/make-payment.handler.js
@@ -4,6 +4,7 @@ import {
   createSetMethodInfoMethodAction,
   createSetMethodInfoNameAction,
   createAddTransactionActionByResponse,
+  getPaymentKeyUpdateAction
 } from './payment-utils.js'
 import c from '../config/constants.js'
 import { makePayment } from '../service/web-component-service.js'
@@ -40,18 +41,8 @@ async function execute(paymentObject) {
     if (action) actions.push(action)
   }
 
-  const paymentKey = paymentObject.key
-  // ensure the key is a string, otherwise the error with "code": "InvalidJsonInput" will return by commercetools API.
-  const reference = requestBodyJson.reference?.toString()
-  const pspReference = response.pspReference?.toString()
-  const newReference = pspReference || reference
-  // ensure the key and new reference is different, otherwise the error with
-  // "code": "InvalidOperation", "message": "'key' has no changes." will return by commercetools API.
-  if (newReference !== paymentKey)
-    actions.push({
-      action: 'setKey',
-      key: newReference,
-    })
+  const updatePaymentAction = getPaymentKeyUpdateAction(paymentObject.key, request, response)
+  if (updatePaymentAction) actions.push(updatePaymentAction)
 
   const addTransactionAction = createAddTransactionActionByResponse(
     paymentObject.amountPlanned.centAmount,

--- a/extension/src/paymentHandler/make-payment.handler.js
+++ b/extension/src/paymentHandler/make-payment.handler.js
@@ -43,12 +43,14 @@ async function execute(paymentObject) {
   const paymentKey = paymentObject.key
   // ensure the key is a string, otherwise the error with "code": "InvalidJsonInput" will return by commercetools API.
   const reference = requestBodyJson.reference?.toString()
+  const pspReference = response.pspReference?.toString()
+  const newReference = pspReference || reference
   // ensure the key and new reference is different, otherwise the error with
   // "code": "InvalidOperation", "message": "'key' has no changes." will return by commercetools API.
-  if (reference !== paymentKey)
+  if (newReference !== paymentKey)
     actions.push({
       action: 'setKey',
-      key: reference,
+      key: newReference,
     })
 
   const addTransactionAction = createAddTransactionActionByResponse(

--- a/extension/src/paymentHandler/make-payment.handler.js
+++ b/extension/src/paymentHandler/make-payment.handler.js
@@ -4,7 +4,7 @@ import {
   createSetMethodInfoMethodAction,
   createSetMethodInfoNameAction,
   createAddTransactionActionByResponse,
-  getPaymentKeyUpdateAction
+  getPaymentKeyUpdateAction,
 } from './payment-utils.js'
 import c from '../config/constants.js'
 import { makePayment } from '../service/web-component-service.js'
@@ -41,7 +41,11 @@ async function execute(paymentObject) {
     if (action) actions.push(action)
   }
 
-  const updatePaymentAction = getPaymentKeyUpdateAction(paymentObject.key, request, response)
+  const updatePaymentAction = getPaymentKeyUpdateAction(
+    paymentObject.key,
+    request,
+    response
+  )
   if (updatePaymentAction) actions.push(updatePaymentAction)
 
   const addTransactionAction = createAddTransactionActionByResponse(

--- a/extension/src/paymentHandler/make-payment.handler.js
+++ b/extension/src/paymentHandler/make-payment.handler.js
@@ -43,8 +43,8 @@ async function execute(paymentObject) {
 
   const updatePaymentAction = getPaymentKeyUpdateAction(
     paymentObject.key,
-    request,
-    response
+    adyenRequest,
+    adyenResponse
   )
   if (updatePaymentAction) actions.push(updatePaymentAction)
 

--- a/extension/src/paymentHandler/payment-utils.js
+++ b/extension/src/paymentHandler/payment-utils.js
@@ -197,7 +197,7 @@ function getIdempotencyKey(transaction) {
   return idempotencyKey
 }
 
-function getPaymentKeyUpdateAction(paymentKey, request, response ) {
+function getPaymentKeyUpdateAction(paymentKey, request, response) {
   const requestBodyJson = JSON.parse(request.body)
   const reference = requestBodyJson.reference?.toString()
   const pspReference = response.pspReference?.toString()
@@ -233,5 +233,5 @@ export {
   isValidJSON,
   isValidMetadata,
   getIdempotencyKey,
-  getPaymentKeyUpdateAction
+  getPaymentKeyUpdateAction,
 }

--- a/extension/src/paymentHandler/payment-utils.js
+++ b/extension/src/paymentHandler/payment-utils.js
@@ -202,7 +202,7 @@ function getPaymentKeyUpdateAction(paymentKey, request, response) {
   const reference = requestBodyJson.reference?.toString()
   const pspReference = response.pspReference?.toString()
   const newReference = pspReference || reference
-  let paymentKeyUpdateAction = {}
+  let paymentKeyUpdateAction
   // ensure the key and new reference is different, otherwise the error with
   // "code": "InvalidOperation", "message": "'key' has no changes." will return by commercetools API.
   if (newReference !== paymentKey) {

--- a/extension/src/paymentHandler/payment-utils.js
+++ b/extension/src/paymentHandler/payment-utils.js
@@ -197,6 +197,23 @@ function getIdempotencyKey(transaction) {
   return idempotencyKey
 }
 
+function getPaymentKeyUpdateAction(paymentKey, request, response ) {
+  const requestBodyJson = JSON.parse(request.body)
+  const reference = requestBodyJson.reference?.toString()
+  const pspReference = response.pspReference?.toString()
+  const newReference = pspReference || reference
+  let paymentKeyUpdateAction = {}
+  // ensure the key and new reference is different, otherwise the error with
+  // "code": "InvalidOperation", "message": "'key' has no changes." will return by commercetools API.
+  if (newReference !== paymentKey) {
+    paymentKeyUpdateAction = {
+      action: 'setKey',
+      key: newReference,
+    }
+  }
+  return paymentKeyUpdateAction
+}
+
 export {
   getChargeTransactionInitial,
   getChargeTransactionPending,
@@ -216,4 +233,5 @@ export {
   isValidJSON,
   isValidMetadata,
   getIdempotencyKey,
+  getPaymentKeyUpdateAction
 }

--- a/extension/src/paymentHandler/submit-payment-details.handler.js
+++ b/extension/src/paymentHandler/submit-payment-details.handler.js
@@ -6,6 +6,7 @@ import {
   createAddTransactionActionByResponse,
 } from './payment-utils.js'
 import c from '../config/constants.js'
+import {getPaymentKeyUpdateAction} from "./payment-utils";
 
 const { CTP_INTERACTION_TYPE_SUBMIT_ADDITIONAL_PAYMENT_DETAILS } = c
 
@@ -53,6 +54,9 @@ async function execute(paymentObject) {
 
       if (addTransactionAction) actions.push(addTransactionAction)
     }
+    const updatePaymentAction = getPaymentKeyUpdateAction(paymentObject.key, request, response)
+    if (updatePaymentAction) actions.push(updatePaymentAction)
+
   }
   return {
     actions,

--- a/extension/src/paymentHandler/submit-payment-details.handler.js
+++ b/extension/src/paymentHandler/submit-payment-details.handler.js
@@ -4,7 +4,7 @@ import {
   createAddInterfaceInteractionAction,
   createSetCustomFieldAction,
   createAddTransactionActionByResponse,
-  getPaymentKeyUpdateAction
+  getPaymentKeyUpdateAction,
 } from './payment-utils.js'
 import c from '../config/constants.js'
 
@@ -54,9 +54,12 @@ async function execute(paymentObject) {
 
       if (addTransactionAction) actions.push(addTransactionAction)
     }
-    const updatePaymentAction = getPaymentKeyUpdateAction(paymentObject.key, request, response)
+    const updatePaymentAction = getPaymentKeyUpdateAction(
+      paymentObject.key,
+      request,
+      response
+    )
     if (updatePaymentAction) actions.push(updatePaymentAction)
-
   }
   return {
     actions,

--- a/extension/src/paymentHandler/submit-payment-details.handler.js
+++ b/extension/src/paymentHandler/submit-payment-details.handler.js
@@ -4,9 +4,9 @@ import {
   createAddInterfaceInteractionAction,
   createSetCustomFieldAction,
   createAddTransactionActionByResponse,
+  getPaymentKeyUpdateAction
 } from './payment-utils.js'
 import c from '../config/constants.js'
-import {getPaymentKeyUpdateAction} from "./payment-utils";
 
 const { CTP_INTERACTION_TYPE_SUBMIT_ADDITIONAL_PAYMENT_DETAILS } = c
 

--- a/extension/test/e2e/pageObjects/AffirmPage.js
+++ b/extension/test/e2e/pageObjects/AffirmPage.js
@@ -6,7 +6,7 @@ export default class AffirmPage {
   async finishAffirmPayment() {
     await this.inputPhoneNumberAndClickSubmitButton()
     await this.inputPIN()
-    await this.clickTermCardAndProceed()
+    await this.choosePlan()
     await this.clickAutoPayToggleAndProceed()
   }
 
@@ -22,12 +22,19 @@ export default class AffirmPage {
     await this.page.waitForSelector('[data-test=term-card]')
   }
 
-  async clickTermCardAndProceed() {
-    await this.page.click('[data-test="term-card"]')
-    await this.page.waitForSelector('#autopay-toggle')
+  async choosePlan() {
+    await this.page.waitForTimeout(1_000)
+
+    const paymentRadioButton = await this.page.$('[data-testid="radio_button"]')
+    await this.page.evaluate((cb) => cb.click(), paymentRadioButton)
+    await this.page.waitForSelector('[data-testid="submit-button"]')
+
+    const submitButton = await this.page.$('[data-testid="submit-button"]')
+    await this.page.evaluate((cb) => cb.click(), submitButton)
   }
 
   async clickAutoPayToggleAndProceed() {
+    await this.page.waitForSelector('#autopay-toggle')
     const autoPayToggle = await this.page.$('#autopay-toggle')
     await this.page.evaluate((cb) => cb.click(), autoPayToggle)
     await this.page.waitForTimeout(1_000) // Wait for the page refreshes after toggling the autopay

--- a/extension/test/e2e/pageObjects/PaypalPopupPage.js
+++ b/extension/test/e2e/pageObjects/PaypalPopupPage.js
@@ -13,7 +13,7 @@ export default class PaypalPopupPage {
     await this.page.click('#acceptAllButton')
     await this.page.type('#password', '!nh-NNS1')
     await this.page.click('#btnLogin')
-    
+
     await this.page.waitForSelector('#payment-submit-btn')
     await this.page.click('#payment-submit-btn')
 

--- a/extension/test/e2e/pageObjects/PaypalPopupPage.js
+++ b/extension/test/e2e/pageObjects/PaypalPopupPage.js
@@ -13,8 +13,7 @@ export default class PaypalPopupPage {
     await this.page.click('#acceptAllButton')
     await this.page.type('#password', '!nh-NNS1')
     await this.page.click('#btnLogin')
-
-    await this.page.waitForTimeout(5000)
+    
     await this.page.waitForSelector('#payment-submit-btn')
     await this.page.click('#payment-submit-btn')
 

--- a/extension/test/e2e/pageObjects/PaypalPopupPage.js
+++ b/extension/test/e2e/pageObjects/PaypalPopupPage.js
@@ -14,7 +14,10 @@ export default class PaypalPopupPage {
     await this.page.type('#password', '!nh-NNS1')
     await this.page.click('#btnLogin')
 
+    await this.page.waitForTimeout(3000)
     await this.page.waitForSelector('#payment-submit-btn')
     await this.page.click('#payment-submit-btn')
+
+    await this.page.waitForTimeout(3000)
   }
 }

--- a/extension/test/e2e/pageObjects/PaypalPopupPage.js
+++ b/extension/test/e2e/pageObjects/PaypalPopupPage.js
@@ -14,10 +14,10 @@ export default class PaypalPopupPage {
     await this.page.type('#password', '!nh-NNS1')
     await this.page.click('#btnLogin')
 
-    await this.page.waitForTimeout(3000)
+    await this.page.waitForTimeout(5000)
     await this.page.waitForSelector('#payment-submit-btn')
     await this.page.click('#payment-submit-btn')
 
-    await this.page.waitForTimeout(3000)
+    await this.page.waitForTimeout(5000)
   }
 }

--- a/extension/test/e2e/pageObjects/PaypalPopupPage.js
+++ b/extension/test/e2e/pageObjects/PaypalPopupPage.js
@@ -15,8 +15,7 @@ export default class PaypalPopupPage {
     await this.page.click('#btnLogin')
 
     await this.page.waitForSelector('#payment-submit-btn')
+    await this.page.waitForTimeout(1000) // Need to suspend 1 second to avoid page closed before loading data.
     await this.page.click('#payment-submit-btn')
-
-    await this.page.waitForTimeout(5000)
   }
 }

--- a/extension/test/integration/make-payment.handler.spec.js
+++ b/extension/test/integration/make-payment.handler.spec.js
@@ -85,8 +85,11 @@ describe('::make-payment with multiple adyen accounts use case::', () => {
         ]
       )
 
+      const makePaymentResponse =
+        updatedPayment?.custom?.fields?.makePaymentResponse
+      const pspReference = JSON.parse(makePaymentResponse).pspReference
       expect(statusCode).to.equal(200)
-      expect(updatedPayment.key).to.equal(makePaymentRequestDraft.reference)
+      expect(updatedPayment.key).to.equal(pspReference)
       expect(updatedPayment.paymentMethodInfo.method).to.equal('scheme')
       expect(updatedPayment.paymentMethodInfo.name).to.eql({
         en: 'Credit Card',
@@ -147,8 +150,9 @@ describe('::make-payment with multiple adyen accounts use case::', () => {
     )
 
     expect(statusCode).to.equal(201)
-
-    expect(payment.key).to.equal(reference)
+    const { makePaymentResponse } = payment.custom.fields
+    const pspReference = JSON.parse(makePaymentResponse).pspReference
+    expect(payment.key).to.equal(pspReference)
     expect(payment.paymentMethodInfo.method).to.equal('scheme')
     expect(payment.paymentMethodInfo.name).to.eql({ en: 'Credit Card' })
 
@@ -172,8 +176,6 @@ describe('::make-payment with multiple adyen accounts use case::', () => {
     expect(makePaymentRequestBody.merchantAccount).to.be.equal(
       adyenMerchantAccount
     )
-
-    const { makePaymentResponse } = payment.custom.fields
 
     expect(makePaymentResponse).to.be.deep.equal(
       interfaceInteraction.fields.response

--- a/extension/test/unit/make-payment-with-splits.handler.spec.js
+++ b/extension/test/unit/make-payment-with-splits.handler.spec.js
@@ -138,7 +138,9 @@ describe('make-payment-with-splits::execute', () => {
       )
 
       const setKeyAction = response.actions.find((a) => a.action === 'setKey')
-      expect(setKeyAction.key).to.equal(makePaymentWithSplitsRequest.reference)
+      expect(setKeyAction.key).to.equal(
+        JSON.parse(paymentSuccessResponse).pspReference
+      )
 
       const addTransaction = response.actions.find(
         (a) => a.action === 'addTransaction'

--- a/extension/test/unit/make-payment.handler.spec.js
+++ b/extension/test/unit/make-payment.handler.spec.js
@@ -124,7 +124,9 @@ describe('make-payment::execute', () => {
       )
 
       const setKeyAction = response.actions.find((a) => a.action === 'setKey')
-      expect(setKeyAction.key).to.equal(makePaymentRequest.reference)
+      expect(setKeyAction.key).to.equal(
+        JSON.parse(paymentSuccessResponse).pspReference
+      )
 
       const addTransaction = response.actions.find(
         (a) => a.action === 'addTransaction'
@@ -184,7 +186,7 @@ describe('make-payment::execute', () => {
       )
 
       const setKeyAction = response.actions.find((a) => a.action === 'setKey')
-      expect(setKeyAction.key).to.equal(makePaymentRequest.reference)
+      expect(setKeyAction.key).to.equal(makePaymentRequest.reference) // no pspReference until submitting additional details in redirect flow
     }
   )
 
@@ -285,7 +287,9 @@ describe('make-payment::execute', () => {
       )
 
       const setKeyAction = response.actions.find((a) => a.action === 'setKey')
-      expect(setKeyAction.key).to.equal(makePaymentRequest.reference)
+      expect(setKeyAction.key).to.equal(
+        JSON.parse(paymentRefusedResponse).pspReference
+      )
 
       const addTransaction = response.actions.find(
         (a) => a.action === 'addTransaction'
@@ -346,7 +350,9 @@ describe('make-payment::execute', () => {
       )
 
       const setKeyAction = response.actions.find((a) => a.action === 'setKey')
-      expect(setKeyAction.key).to.equal(makePaymentRequest.reference)
+      expect(setKeyAction.key).to.equal(
+        JSON.parse(paymentErrorResponse).pspReference
+      )
 
       const addTransaction = response.actions.find(
         (a) => a.action === 'addTransaction'

--- a/extension/test/unit/submit-payment-details.handler.spec.js
+++ b/extension/test/unit/submit-payment-details.handler.spec.js
@@ -59,7 +59,7 @@ describe('submit-additional-payment-details::execute', () => {
 
       const response = await execute(ctpPaymentClone)
 
-      expect(response.actions).to.have.lengthOf(3)
+      expect(response.actions).to.have.lengthOf(4)
       const addInterfaceInteraction = response.actions.find(
         (a) => a.action === 'addInterfaceInteraction'
       )
@@ -114,6 +114,10 @@ describe('submit-additional-payment-details::execute', () => {
       expect(addTransaction.transaction.type).to.equal('Authorization')
       expect(addTransaction.transaction.state).to.equal('Success')
       expect(addTransaction.transaction.interactionId).to.equal(
+        JSON.parse(submitPaymentDetailsSuccessResponse).pspReference
+      )
+      const setKeyAction = response.actions.find((a) => a.action === 'setKey')
+      expect(setKeyAction.key).to.equal(
         JSON.parse(submitPaymentDetailsSuccessResponse).pspReference
       )
     }
@@ -275,7 +279,7 @@ describe('submit-additional-payment-details::execute', () => {
 
       const response = await execute(ctpPaymentClone)
 
-      expect(response.actions).to.have.lengthOf(3)
+      expect(response.actions).to.have.lengthOf(4)
       const addInterfaceInteractionAction = response.actions.find(
         (a) => a.action === 'addInterfaceInteraction'
       )
@@ -286,7 +290,10 @@ describe('submit-additional-payment-details::execute', () => {
         (a) => a.action === 'setCustomField'
       )
       expect(setCustomFieldAction.value).to.include('additionalData')
-
+      const setKeyAction = response.actions.find((a) => a.action === 'setKey')
+      expect(setKeyAction.key).to.equal(
+        JSON.parse(submitPaymentDetailsSuccessResponse).pspReference
+      )
       sandbox.restore()
     }
   )
@@ -321,7 +328,7 @@ describe('submit-additional-payment-details::execute', () => {
 
       const response = await execute(ctpPaymentClone)
 
-      expect(response.actions).to.have.lengthOf(3)
+      expect(response.actions).to.have.lengthOf(4)
       const addInterfaceInteractionAction = response.actions.find(
         (a) => a.action === 'addInterfaceInteraction'
       )
@@ -332,7 +339,10 @@ describe('submit-additional-payment-details::execute', () => {
         (a) => a.action === 'setCustomField'
       )
       expect(setCustomFieldAction.value).to.not.include('additionalData')
-
+      const setKeyAction = response.actions.find((a) => a.action === 'setKey')
+      expect(setKeyAction.key).to.equal(
+        JSON.parse(submitPaymentDetailsSuccessResponse).pspReference
+      )
       sandbox.restore()
     }
   )
@@ -367,11 +377,15 @@ describe('submit-additional-payment-details::execute', () => {
 
       const response = await execute(ctpPaymentClone)
 
-      expect(response.actions).to.have.lengthOf(2)
+      expect(response.actions).to.have.lengthOf(3)
       const addTransaction = response.actions.find(
         (a) => a.action === 'addTransaction'
       )
       expect(addTransaction).to.be.undefined
+      const setKeyAction = response.actions.find((a) => a.action === 'setKey')
+      expect(setKeyAction.key).to.equal(
+        JSON.parse(submitPaymentDetailsSuccessResponse).pspReference
+      )
     }
   )
 })

--- a/notification/docs/IntegrationGuide.md
+++ b/notification/docs/IntegrationGuide.md
@@ -99,7 +99,7 @@ and [transactionState](https://docs.commercetools.com/http-api-projects-payments
 > All mappings can be found in the [adyen-events.json](./../resources/adyen-events.json) file.
 
 After finding a mapping the notification module will find a matching payment on a commercetools project.
-To find the matching payment, `merchantReference` field from the notification is used to find a payment by key
+To find the matching payment, `merchantReference`, `pspReference` and `originalReference` fields from the notification are used to find a payment by key
 and `pspReference` field from the notification is used to find a transaction by its interactionId.
 
 If there is no transaction on the payment found,

--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -203,17 +203,12 @@ async function calculateUpdateActionsForPayment(payment, notification, logger) {
       )
     }
     const paymentKey = payment.key
-
-    if (
-      notificationRequestItem.eventCode === 'AUTHORISATION' &&
-      (notificationRequestItem.success === 'true' ||
-        notificationRequestItem.success === true) &&
-      pspReference !== paymentKey &&
-      oldTransaction?.state !== 'Success'
-    ) {
+    const newPspReference =
+      notificationRequestItem.originalReference || pspReference
+    if (newPspReference && newPspReference !== paymentKey) {
       updateActions.push({
         action: 'setKey',
-        key: pspReference,
+        key: newPspReference,
       })
     }
   }

--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -213,7 +213,21 @@ async function calculateUpdateActionsForPayment(payment, notification, logger) {
         )
       )
     }
+    const paymentKey = payment.key
+
+    if (
+      notificationRequestItem.eventCode === 'AUTHORISATION' &&
+      JSON.parse(notificationRequestItem.success) === true && // convert 'success' from string to boolean type
+      pspReference !== paymentKey &&
+      oldTransaction?.state !== 'Success'
+    ) {
+      updateActions.push({
+        action: 'setKey',
+        key: pspReference,
+      })
+    }
   }
+
   const paymentMethodFromPayment = payment.paymentMethodInfo.method
   const paymentMethodFromNotification = notificationRequestItem.paymentMethod
   if (
@@ -225,17 +239,6 @@ async function calculateUpdateActionsForPayment(payment, notification, logger) {
     )
     const action = getSetMethodInfoNameAction(paymentMethodFromNotification)
     if (action) updateActions.push(action)
-  }
-  const paymentKey = payment.key
-  if (
-    notificationRequestItem.eventCode === 'AUTHORISATION' &&
-    JSON.parse(notificationRequestItem.success) === true && // convert 'success' from string to boolean type
-    pspReference !== paymentKey
-  ) {
-    updateActions.push({
-      action: 'setKey',
-      key: pspReference,
-    })
   }
 
   return updateActions

--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -413,12 +413,13 @@ async function getPaymentByMerchantReference(
 ) {
   try {
     const keys = [merchantReference, pspReference]
+    console.log(keys)
     const result = await ctpClient.fetchByKeys(ctpClient.builder.payments, keys)
     return result.body.results[0]
   } catch (err) {
     if (err.statusCode === 404) return null
     const errMsg =
-      `Failed to fetch a payment with merchantReference: ${merchantReference}. ` +
+      `Failed to fetch a payment with merchantReference ${merchantReference} and pspReference ${pspReference}. ` +
       `Error: ${JSON.stringify(serializeError(err))}`
     throw new VError(err, errMsg)
   }

--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -217,7 +217,7 @@ async function calculateUpdateActionsForPayment(payment, notification, logger) {
 
     if (
       notificationRequestItem.eventCode === 'AUTHORISATION' &&
-      JSON.parse(notificationRequestItem.success) === true && // convert 'success' from string to boolean type
+      (notificationRequestItem.success === "true" || notificationRequestItem.success === true) &&
       pspReference !== paymentKey &&
       oldTransaction?.state !== 'Success'
     ) {

--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -229,7 +229,7 @@ async function calculateUpdateActionsForPayment(payment, notification, logger) {
   const paymentKey = payment.key
   if (
     notificationRequestItem.eventCode === 'AUTHORISATION' &&
-    notificationRequestItem.success === true &&
+    JSON.parse(notificationRequestItem.success) === true && // convert 'success' from string to boolean type
     pspReference !== paymentKey
   ) {
     updateActions.push({
@@ -420,9 +420,9 @@ async function getPaymentByMerchantReference(
   ctpClient
 ) {
   try {
-    const keys = [merchantReference, pspReference, '1670715051384']
+    const keys = [merchantReference, pspReference]
     const result = await ctpClient.fetchByKeys(ctpClient.builder.payments, keys)
-    return result.body[0]
+    return result.body.results[0]
   } catch (err) {
     if (err.statusCode === 404) return null
     const errMsg =

--- a/notification/src/handler/notification/notification.handler.js
+++ b/notification/src/handler/notification/notification.handler.js
@@ -34,13 +34,6 @@ async function processNotification(
     'NotificationRequestItem.merchantReference',
     null
   )
-  if (merchantReference === null) {
-    logger.error(
-      { notification: utils.getNotificationForTracking(notification) },
-      "Can't extract merchantReference from the notification"
-    )
-    return
-  }
 
   const pspReference = _.get(
     notification,
@@ -217,7 +210,8 @@ async function calculateUpdateActionsForPayment(payment, notification, logger) {
 
     if (
       notificationRequestItem.eventCode === 'AUTHORISATION' &&
-      (notificationRequestItem.success === "true" || notificationRequestItem.success === true) &&
+      (notificationRequestItem.success === 'true' ||
+        notificationRequestItem.success === true) &&
       pspReference !== paymentKey &&
       oldTransaction?.state !== 'Success'
     ) {

--- a/notification/src/utils/ctp.js
+++ b/notification/src/utils/ctp.js
@@ -113,6 +113,15 @@ async function setUpClient(config) {
       return ctpClient.execute(this.buildRequestOptions(uri.byKey(key).build()))
     },
 
+    fetchByKeys(uri, keys) {
+      const keyList = keys.map((key) => `"${key}"`)
+      const keyConditions = `key in (${keyList.join(',')})`
+
+      return ctpClient.execute(
+        this.buildRequestOptions(uri.where(keyConditions).build())
+      )
+    },
+
     fetchBatches(uri, callback, opts = { accumulate: false }) {
       return this.process(
         this.buildRequestOptions(uri.build()),

--- a/notification/src/utils/ctp.js
+++ b/notification/src/utils/ctp.js
@@ -113,15 +113,6 @@ async function setUpClient(config) {
       return ctpClient.execute(this.buildRequestOptions(uri.byKey(key).build()))
     },
 
-    fetchByKeys(uri, keys) {
-      const keyList = keys.map((key) => `"${key}"`)
-      const keyConditions = `key in (${keyList.join(',')})`
-
-      return ctpClient.execute(
-        this.buildRequestOptions(uri.where(keyConditions).build())
-      )
-    },
-
     fetchBatches(uri, callback, opts = { accumulate: false }) {
       return this.process(
         this.buildRequestOptions(uri.build()),

--- a/notification/test/integration/multitenancy.spec.js
+++ b/notification/test/integration/multitenancy.spec.js
@@ -29,18 +29,22 @@ describe('::multitenancy::', () => {
   })
 
   it('should process payment correctly when notifications are from different projects', async () => {
-    const payment1Key = `notificationPayment1-${new Date().getTime()}`
-    const payment2Key = `notificationPayment2-${new Date().getTime()}`
+    const merchantReference1 = `notificationPayment1-${new Date().getTime()}`
+    const merchantReference2 = `notificationPayment2-${new Date().getTime()}`
+    const pspReference1 = `pspReference1-${new Date().getTime()}`
+    const pspReference2 = `pspReference2-${new Date().getTime()}`
     await Promise.all([
       ensurePayment(
         ctpClient1,
-        payment1Key,
+        merchantReference1,
+        pspReference1,
         commercetoolsProjectKey1,
         adyenMerchantAccount1
       ),
       ensurePayment(
         ctpClient2,
-        payment2Key,
+        merchantReference2,
+        pspReference2,
         commercetoolsProjectKey2,
         adyenMerchantAccount2
       ),
@@ -49,13 +53,15 @@ describe('::multitenancy::', () => {
     const notificationPayload1 = createNotificationPayload(
       commercetoolsProjectKey1,
       adyenMerchantAccount1,
-      payment1Key
+      merchantReference1,
+      pspReference1
     )
 
     const notificationPayload2 = createNotificationPayload(
       commercetoolsProjectKey2,
       adyenMerchantAccount2,
-      payment2Key
+      merchantReference2,
+      pspReference2
     )
 
     const [response1, response2] = await Promise.all([
@@ -78,12 +84,12 @@ describe('::multitenancy::', () => {
 
     const { body: paymentAfter1 } = await ctpClient1.fetchByKey(
       ctpClient1.builder.payments,
-      payment1Key
+      pspReference1 // pspReference is the key of authorized payment
     )
 
     const { body: paymentAfter2 } = await ctpClient2.fetchByKey(
       ctpClient2.builder.payments,
-      payment2Key
+      pspReference2 // pspReference is the key of authorized payment
     )
 
     expect(paymentAfter1.transactions).to.have.lengthOf(1)

--- a/notification/test/integration/notification.handler.spec.js
+++ b/notification/test/integration/notification.handler.spec.js
@@ -26,10 +26,14 @@ describe('notification module', () => {
     'should update the pending authorization transaction state to success state ' +
       'when receives a successful AUTHORIZATION notification',
     async () => {
-      const paymentKey = `notificationPayment-${new Date().getTime()}`
+      const merchantReference = `notificationPayment-${new Date().getTime()}`
+      // pspReference cannot be static otherwise wrong payment created in the past would be obtained
+      const pspReference = `pspReference-${new Date().getTime()}`
+
       const { body: paymentBefore } = await ensurePayment(
         ctpClient,
-        paymentKey,
+        merchantReference,
+        pspReference,
         commercetoolsProjectKey,
         adyenMerchantAccount
       )
@@ -41,7 +45,8 @@ describe('notification module', () => {
       const notificationPayload = createNotificationPayload(
         commercetoolsProjectKey,
         adyenMerchantAccount,
-        paymentKey
+        merchantReference,
+        pspReference
       )
 
       // Simulating a notification from Adyen
@@ -58,8 +63,9 @@ describe('notification module', () => {
 
       const { body: paymentAfter } = await ctpClient.fetchByKey(
         ctpClient.builder.payments,
-        paymentKey
+        pspReference // pspReference is the key of authorized payment
       )
+
       expect(paymentAfter.transactions).to.have.lengthOf(1)
       expect(paymentAfter.paymentMethodInfo.method).to.equal('visa')
       expect(paymentAfter.transactions[0].type).to.equal('Authorization')
@@ -76,10 +82,14 @@ describe('notification module', () => {
   )
 
   it('should add a charge transaction when receives a successful manual CAPTURE notification', async () => {
-    const paymentKey = `notificationPayment-${new Date().getTime()}`
+    const merchantReference = `notificationPayment-${new Date().getTime()}`
+    // pspReference cannot be static otherwise payment created in the past would be wrongly obtained
+    const pspReference = `pspReference-${new Date().getTime()}`
+    const chargeInteractionId = _generateRandomNumber()
     const { body: paymentBefore } = await ensurePayment(
       ctpClient,
-      paymentKey,
+      merchantReference,
+      pspReference,
       commercetoolsProjectKey,
       adyenMerchantAccount
     )
@@ -88,12 +98,16 @@ describe('notification module', () => {
     expect(paymentBefore.transactions[0].state).to.equal('Pending')
     expect(paymentBefore.interfaceInteractions).to.have.lengthOf(0)
 
-    // update payment transaction
+    // update payment transaction and set pspReference as key for authorized payment
     const actions = [
       {
         action: 'changeTransactionState',
         state: 'Success',
         transactionId: paymentBefore.transactions[0].id,
+      },
+      {
+        action: 'setKey',
+        key: pspReference,
       },
     ]
 
@@ -111,9 +125,11 @@ describe('notification module', () => {
     const notificationPayload = createNotificationPayload(
       commercetoolsProjectKey,
       adyenMerchantAccount,
-      paymentKey,
+      merchantReference,
+      chargeInteractionId,
       'CAPTURE',
-      _generateRandomNumber()
+      'true',
+      pspReference
     )
 
     // Simulating a notification from Adyen
@@ -130,7 +146,7 @@ describe('notification module', () => {
 
     const { body: paymentAfter } = await ctpClient.fetchByKey(
       ctpClient.builder.payments,
-      paymentKey
+      pspReference // pspReference is the key of authorized payment
     )
     expect(paymentAfter.transactions).to.have.lengthOf(2)
     expect(paymentAfter.transactions[0].type).to.equal('Authorization')
@@ -152,10 +168,13 @@ describe('notification module', () => {
     'should not update transaction when the notification event ' +
       'is not mapped to any CTP payment state',
     async () => {
-      const paymentKey = `notificationPayment-${new Date().getTime()}`
+      const merchantReference = `notificationPayment-${new Date().getTime()}`
+      // pspReference cannot be static otherwise payment created in the past would be wrongly obtained
+      const pspReference = `pspReference-${new Date().getTime()}`
       const { body: paymentBefore } = await ensurePayment(
         ctpClient,
-        paymentKey,
+        merchantReference,
+        pspReference,
         commercetoolsProjectKey,
         adyenMerchantAccount
       )
@@ -167,7 +186,8 @@ describe('notification module', () => {
       const notificationPayload = createNotificationPayload(
         commercetoolsProjectKey,
         adyenMerchantAccount,
-        paymentKey,
+        merchantReference,
+        pspReference,
         'UNKNOWN_EVENT_CODE'
       )
 
@@ -185,7 +205,7 @@ describe('notification module', () => {
 
       const { body: paymentAfter } = await ctpClient.fetchByKey(
         ctpClient.builder.payments,
-        paymentKey
+        merchantReference // merchantReference is the key of unauthorized payment
       )
       expect(paymentAfter.transactions).to.have.lengthOf(1)
       expect(paymentAfter.transactions[0].type).to.equal('Authorization')
@@ -202,10 +222,13 @@ describe('notification module', () => {
   )
 
   it('should response with success when payment does not exist on the platform', async () => {
-    const paymentKey = `notificationPayment-${new Date().getTime()}`
+    const merchantReference = `notificationPayment-${new Date().getTime()}`
+    // pspReference cannot be static otherwise payment created in the past would be wrongly obtained
+    const pspReference = `pspReference-${new Date().getTime()}`
     const { body: paymentBefore } = await ensurePayment(
       ctpClient,
-      paymentKey,
+      merchantReference,
+      pspReference,
       commercetoolsProjectKey,
       adyenMerchantAccount
     )
@@ -217,7 +240,8 @@ describe('notification module', () => {
     const notificationPayload = createNotificationPayload(
       commercetoolsProjectKey,
       adyenMerchantAccount,
-      paymentKey,
+      merchantReference,
+      pspReference,
       'NOT_EXISTING_PAYMENT'
     )
 
@@ -235,7 +259,7 @@ describe('notification module', () => {
 
     const { body: paymentAfter } = await ctpClient.fetchByKey(
       ctpClient.builder.payments,
-      paymentKey
+      merchantReference // merchantReference is the key of unauthorized payment
     )
     expect(paymentAfter.transactions).to.have.lengthOf(1)
     expect(paymentAfter.transactions[0].type).to.equal('Authorization')
@@ -247,10 +271,14 @@ describe('notification module', () => {
     'should update the pending Refund transaction state to success state ' +
       'when receives a successful REFUND notification with refund action',
     async () => {
-      const paymentKey = `notificationPayment-${new Date().getTime()}`
+      const merchantReference = `notificationPayment-${new Date().getTime()}`
+      // pspReference cannot be static otherwise payment created in the past would be wrongly obtained
+      const pspReference = `pspReference-${new Date().getTime()}`
+
       const { body: paymentBefore } = await ensurePayment(
         ctpClient,
-        paymentKey,
+        merchantReference,
+        pspReference,
         commercetoolsProjectKey,
         adyenMerchantAccount
       )
@@ -278,6 +306,11 @@ describe('notification module', () => {
             interactionId: refundInteractionId,
           },
         },
+        // Change the payment key to pspReference for authorized payment
+        {
+          action: 'setKey',
+          key: pspReference,
+        },
       ]
 
       const { body: updatedPayment } = await ctpClient.update(
@@ -296,9 +329,11 @@ describe('notification module', () => {
       const notificationPayload = createNotificationPayload(
         commercetoolsProjectKey,
         adyenMerchantAccount,
-        paymentKey,
+        merchantReference,
+        refundInteractionId,
         'REFUND',
-        refundInteractionId
+        'true',
+        pspReference
       )
 
       // Simulating a notification from Adyen
@@ -315,7 +350,7 @@ describe('notification module', () => {
 
       const { body: paymentAfter } = await ctpClient.fetchByKey(
         ctpClient.builder.payments,
-        paymentKey
+        pspReference // pspReference is the key of authorized payment
       )
       expect(paymentAfter.transactions).to.have.lengthOf(2)
       expect(paymentAfter.transactions[0].type).to.equal('Authorization')
@@ -338,10 +373,13 @@ describe('notification module', () => {
     'should update multiple pending Refund transaction states to corresponding states ' +
       'when receives multiple REFUND notifications',
     async () => {
-      const paymentKey = `notificationPayment-${new Date().getTime()}`
+      const merchantReference = `notificationPayment-${new Date().getTime()}`
+      // pspReference cannot be static otherwise payment created in the past would be wrongly obtained
+      const pspReference = `pspReference-${new Date().getTime()}`
       const { body: paymentBefore } = await ensurePayment(
         ctpClient,
-        paymentKey,
+        merchantReference,
+        pspReference,
         commercetoolsProjectKey,
         adyenMerchantAccount
       )
@@ -385,6 +423,11 @@ describe('notification module', () => {
             interactionId: refundInteractionId3,
           },
         },
+        // Change the payment key to pspReference for authorized payment
+        {
+          action: 'setKey',
+          key: pspReference,
+        },
       ]
       await ctpClient.update(
         ctpClient.builder.payments,
@@ -396,26 +439,31 @@ describe('notification module', () => {
       const notificationPayload1 = createNotificationPayload(
         commercetoolsProjectKey,
         adyenMerchantAccount,
-        paymentKey,
+        merchantReference,
+        refundInteractionId1,
         'REFUND',
-        refundInteractionId1
+        'true',
+        pspReference
       )
 
       const notificationPayload2 = createNotificationPayload(
         commercetoolsProjectKey,
         adyenMerchantAccount,
-        paymentKey,
+        merchantReference,
+        refundInteractionId2,
         'REFUND',
-        refundInteractionId2
+        'true',
+        pspReference
       )
 
       const notificationPayload3 = createNotificationPayload(
         commercetoolsProjectKey,
         adyenMerchantAccount,
-        paymentKey,
-        'REFUND',
+        merchantReference,
         refundInteractionId3,
-        'false'
+        'REFUND',
+        'false',
+        pspReference
       )
 
       // Simulating notifications from Adyen
@@ -449,7 +497,7 @@ describe('notification module', () => {
 
       const { body: paymentAfter } = await ctpClient.fetchByKey(
         ctpClient.builder.payments,
-        paymentKey
+        pspReference // pspReference is the key of authorized payment
       )
       expect(paymentAfter.transactions).to.have.lengthOf(4)
       expect(paymentAfter.transactions[1].type).to.equal('Refund')
@@ -465,10 +513,13 @@ describe('notification module', () => {
     'should update the pending CancelAuthorization transaction state to success state ' +
       'when receives a successful CANCEL notification with cancel action',
     async () => {
-      const paymentKey = `notificationPayment-${new Date().getTime()}`
+      const merchantReference = `notificationPayment-${new Date().getTime()}`
+      // pspReference cannot be static otherwise payment created in the past would be wrongly obtained
+      const pspReference = `pspReference-${new Date().getTime()}`
       const { body: paymentBefore } = await ensurePayment(
         ctpClient,
-        paymentKey,
+        merchantReference,
+        pspReference,
         commercetoolsProjectKey,
         adyenMerchantAccount
       )
@@ -511,9 +562,11 @@ describe('notification module', () => {
       const notificationPayload = createNotificationPayload(
         commercetoolsProjectKey,
         adyenMerchantAccount,
-        paymentKey,
+        merchantReference,
+        cancellationInteractionId,
         'CANCEL_OR_REFUND',
-        cancellationInteractionId
+        'true',
+        pspReference
       )
 
       // Simulating a notification from Adyen
@@ -530,7 +583,7 @@ describe('notification module', () => {
 
       const { body: paymentAfter } = await ctpClient.fetchByKey(
         ctpClient.builder.payments,
-        paymentKey
+        merchantReference // merchantReference is the key of unauthorized payment
       )
       expect(paymentAfter.transactions).to.have.lengthOf(2)
       expect(paymentAfter.transactions[0].type).to.equal('Authorization')
@@ -550,10 +603,13 @@ describe('notification module', () => {
   )
 
   it('should not update payment when the notification is unauthorised', async () => {
-    const paymentKey = `notificationPayment-${new Date().getTime()}`
+    const merchantReference = `notificationPayment-${new Date().getTime()}`
+    // pspReference cannot be static otherwise payment created in the past would be wrongly obtained
+    const pspReference = `pspReference-${new Date().getTime()}`
     const { body: paymentBefore } = await ensurePayment(
       ctpClient,
-      paymentKey,
+      merchantReference,
+      pspReference,
       commercetoolsProjectKey,
       adyenMerchantAccount
     )
@@ -572,7 +628,8 @@ describe('notification module', () => {
     const notificationPayload = createNotificationPayload(
       commercetoolsProjectKey,
       adyenMerchantAccount,
-      paymentKey
+      merchantReference,
+      pspReference
     )
 
     // Simulating a modification by a middle man during transmission
@@ -592,7 +649,7 @@ describe('notification module', () => {
 
     const { body: paymentAfter } = await ctpClient.fetchByKey(
       ctpClient.builder.payments,
-      paymentKey
+      merchantReference // merchantReference is the key of unauthorized payment
     )
     expect(paymentAfter.transactions).to.have.lengthOf(1)
     expect(paymentAfter.transactions[0].type).to.equal('Authorization')
@@ -603,10 +660,13 @@ describe('notification module', () => {
   })
 
   it('should use URL path as a fallback when metadata.ctProjectKey is missing', async () => {
-    const paymentKey = `notificationPayment-${new Date().getTime()}`
+    const merchantReference = `notificationPayment-${new Date().getTime()}`
+    // pspReference cannot be static otherwise payment created in the past would be wrongly obtained
+    const pspReference = `pspReference-${new Date().getTime()}`
     const { body: paymentBefore } = await ensurePayment(
       ctpClient,
-      paymentKey,
+      merchantReference,
+      pspReference,
       commercetoolsProjectKey,
       adyenMerchantAccount
     )
@@ -618,7 +678,8 @@ describe('notification module', () => {
     const notificationPayload = createNotificationPayload(
       null,
       adyenMerchantAccount,
-      paymentKey
+      merchantReference,
+      pspReference
     )
 
     // Simulating a notification from Adyen
@@ -639,7 +700,7 @@ describe('notification module', () => {
 
     const { body: paymentAfter } = await ctpClient.fetchByKey(
       ctpClient.builder.payments,
-      paymentKey
+      pspReference // pspReference is the key of authorized payment
     )
     expect(paymentAfter.transactions).to.have.lengthOf(1)
     expect(paymentAfter.transactions[0].type).to.equal('Authorization')

--- a/notification/test/integration/notification.handler.spec.js
+++ b/notification/test/integration/notification.handler.spec.js
@@ -529,6 +529,7 @@ describe('notification module', () => {
       expect(paymentBefore.interfaceInteractions).to.have.lengthOf(0)
 
       const cancellationInteractionId = _generateRandomNumber()
+
       const actions = [
         {
           action: 'addTransaction',
@@ -542,6 +543,16 @@ describe('notification module', () => {
             interactionId: cancellationInteractionId,
           },
         },
+        {
+          action: 'changeTransactionState',
+          state: 'Success',
+          transactionId: paymentBefore.transactions[0].id,
+        },
+        // Change the payment key to pspReference for authorized payment
+        {
+          action: 'setKey',
+          key: pspReference,
+        },
       ]
 
       const { body: updatedPayment } = await ctpClient.update(
@@ -553,7 +564,7 @@ describe('notification module', () => {
 
       expect(updatedPayment.transactions).to.have.lengthOf(2)
       expect(updatedPayment.transactions[0].type).to.equal('Authorization')
-      expect(updatedPayment.transactions[0].state).to.equal('Pending')
+      expect(updatedPayment.transactions[0].state).to.equal('Success')
       expect(updatedPayment.transactions[1].type).to.equal(
         'CancelAuthorization'
       )
@@ -583,11 +594,12 @@ describe('notification module', () => {
 
       const { body: paymentAfter } = await ctpClient.fetchByKey(
         ctpClient.builder.payments,
-        merchantReference // merchantReference is the key of unauthorized payment
+        pspReference // pspReference is the key of authorized payment
       )
+
       expect(paymentAfter.transactions).to.have.lengthOf(2)
       expect(paymentAfter.transactions[0].type).to.equal('Authorization')
-      expect(paymentAfter.transactions[0].state).to.equal('Pending')
+      expect(paymentAfter.transactions[0].state).to.equal('Success')
       expect(paymentAfter.transactions[1].type).to.equal('CancelAuthorization')
       expect(paymentAfter.transactions[1].state).to.equal('Success')
 

--- a/notification/test/integration/notification.handler.spec.js
+++ b/notification/test/integration/notification.handler.spec.js
@@ -529,7 +529,6 @@ describe('notification module', () => {
       expect(paymentBefore.interfaceInteractions).to.have.lengthOf(0)
 
       const cancellationInteractionId = _generateRandomNumber()
-
       const actions = [
         {
           action: 'addTransaction',
@@ -543,16 +542,6 @@ describe('notification module', () => {
             interactionId: cancellationInteractionId,
           },
         },
-        {
-          action: 'changeTransactionState',
-          state: 'Success',
-          transactionId: paymentBefore.transactions[0].id,
-        },
-        // Change the payment key to pspReference for authorized payment
-        {
-          action: 'setKey',
-          key: pspReference,
-        },
       ]
 
       const { body: updatedPayment } = await ctpClient.update(
@@ -564,7 +553,7 @@ describe('notification module', () => {
 
       expect(updatedPayment.transactions).to.have.lengthOf(2)
       expect(updatedPayment.transactions[0].type).to.equal('Authorization')
-      expect(updatedPayment.transactions[0].state).to.equal('Success')
+      expect(updatedPayment.transactions[0].state).to.equal('Pending')
       expect(updatedPayment.transactions[1].type).to.equal(
         'CancelAuthorization'
       )
@@ -594,12 +583,11 @@ describe('notification module', () => {
 
       const { body: paymentAfter } = await ctpClient.fetchByKey(
         ctpClient.builder.payments,
-        pspReference // pspReference is the key of authorized payment
+        merchantReference // merchantReference is the key of unauthorized payment
       )
-
       expect(paymentAfter.transactions).to.have.lengthOf(2)
       expect(paymentAfter.transactions[0].type).to.equal('Authorization')
-      expect(paymentAfter.transactions[0].state).to.equal('Success')
+      expect(paymentAfter.transactions[0].state).to.equal('Pending')
       expect(paymentAfter.transactions[1].type).to.equal('CancelAuthorization')
       expect(paymentAfter.transactions[1].state).to.equal('Success')
 

--- a/notification/test/integration/notification.handler.spec.js
+++ b/notification/test/integration/notification.handler.spec.js
@@ -542,6 +542,17 @@ describe('notification module', () => {
             interactionId: cancellationInteractionId,
           },
         },
+        {
+          action: 'changeTransactionState',
+          state: 'Success',
+          transactionId: paymentBefore.transactions[0].id,
+        },
+
+        // Change the payment key to pspReference for authorized payment
+        {
+          action: 'setKey',
+          key: pspReference,
+        },
       ]
 
       const { body: updatedPayment } = await ctpClient.update(
@@ -553,7 +564,7 @@ describe('notification module', () => {
 
       expect(updatedPayment.transactions).to.have.lengthOf(2)
       expect(updatedPayment.transactions[0].type).to.equal('Authorization')
-      expect(updatedPayment.transactions[0].state).to.equal('Pending')
+      expect(updatedPayment.transactions[0].state).to.equal('Success')
       expect(updatedPayment.transactions[1].type).to.equal(
         'CancelAuthorization'
       )
@@ -583,11 +594,11 @@ describe('notification module', () => {
 
       const { body: paymentAfter } = await ctpClient.fetchByKey(
         ctpClient.builder.payments,
-        merchantReference // merchantReference is the key of unauthorized payment
+        pspReference // pspReference is the key of authorized payment
       )
       expect(paymentAfter.transactions).to.have.lengthOf(2)
       expect(paymentAfter.transactions[0].type).to.equal('Authorization')
-      expect(paymentAfter.transactions[0].state).to.equal('Pending')
+      expect(paymentAfter.transactions[0].state).to.equal('Success')
       expect(paymentAfter.transactions[1].type).to.equal('CancelAuthorization')
       expect(paymentAfter.transactions[1].state).to.equal('Success')
 

--- a/notification/test/test-utils.js
+++ b/notification/test/test-utils.js
@@ -87,10 +87,11 @@ const validator = new hmacValidator()
 function createNotificationPayload(
   commercetoolsProjectKey,
   adyenMerchantAccount,
-  paymentKey,
+  merchantReference,
+  pspReference,
   eventCode = 'AUTHORISATION',
-  pspReference = 'test_AUTHORISATION_1',
-  success = 'true'
+  success = 'true',
+  originalReference
 ) {
   const notification = {
     live: 'false',
@@ -107,10 +108,11 @@ function createNotificationPayload(
           eventCode,
           eventDate: '2019-01-30T18:16:22+01:00',
           merchantAccountCode: adyenMerchantAccount,
-          merchantReference: paymentKey,
+          merchantReference,
           operations: ['CANCEL', 'CAPTURE', 'REFUND'],
           paymentMethod: 'visa',
           pspReference,
+          originalReference,
           success,
         },
       },
@@ -138,6 +140,7 @@ function createNotificationPayload(
 async function ensurePayment(
   ctpClient,
   paymentKey,
+  pspReference,
   commercetoolsProjectKey,
   adyenMerchantAccount
 ) {
@@ -150,7 +153,9 @@ async function ensurePayment(
     commercetoolsProjectKey,
     adyenMerchantAccount,
   }
-
+  if (pspReference) {
+    paymentDraft.transactions[0].interactionId = pspReference
+  }
   return ctpClient.create(ctpClient.builder.payments, paymentDraft)
 }
 

--- a/notification/test/unit/ctp-client-mock.js
+++ b/notification/test/unit/ctp-client-mock.js
@@ -45,6 +45,10 @@ function setUpClient(config) {
       return this
     },
 
+    fetchByKeys() {
+      return this
+    },
+
     fetchBatches() {
       return this
     },

--- a/notification/test/unit/notification.controller.spec.js
+++ b/notification/test/unit/notification.controller.spec.js
@@ -194,8 +194,8 @@ describe('notification controller', () => {
       }
       const ctpClient = ctpClientMock.get(ctpConfig)
       const modifiedPaymentMock = cloneDeep(paymentMock)
-      sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-        body: modifiedPaymentMock,
+      sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+        body: { results: [modifiedPaymentMock] },
       }))
       sandbox.stub(ctpClient, 'fetchById').callsFake(() => ({
         body: modifiedPaymentMock,

--- a/notification/test/unit/notification.controller.spec.js
+++ b/notification/test/unit/notification.controller.spec.js
@@ -194,8 +194,8 @@ describe('notification controller', () => {
       }
       const ctpClient = ctpClientMock.get(ctpConfig)
       const modifiedPaymentMock = cloneDeep(paymentMock)
-      sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
-        body: { results: [modifiedPaymentMock] },
+      sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
+        body: modifiedPaymentMock,
       }))
       sandbox.stub(ctpClient, 'fetchById').callsFake(() => ({
         body: modifiedPaymentMock,

--- a/notification/test/unit/notification.handler.spec.js
+++ b/notification/test/unit/notification.handler.spec.js
@@ -222,6 +222,10 @@ describe('notification module', () => {
           notification: JSON.stringify(notifications[0]),
         },
       },
+      {
+        action: 'setKey',
+        key: 'test_AUTHORISATION_1',
+      },
     ]
 
     // assert update actions
@@ -285,6 +289,12 @@ describe('notification module', () => {
         createdAt: '2019-02-05T12:29:36.028Z',
       },
     })
+    const expectedUpdateActions = [
+      {
+        action: 'setKey',
+        key: 'test_AUTHORISATION_1',
+      },
+    ]
     const ctpClient = ctpClientMock.get(ctpConfig)
     sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
       body: payment,
@@ -299,7 +309,13 @@ describe('notification module', () => {
       config
     )
     // assert
-    expect(ctpClientUpdateSpy.callCount).to.equal(0)
+    expect(ctpClientUpdateSpy.callCount).to.equal(1)
+
+    const actualUpdateActionsWithoutCreatedAt = ctpClientUpdateSpy.args[0][3]
+
+    expect(actualUpdateActionsWithoutCreatedAt).to.deep.equal(
+      expectedUpdateActions
+    )
   })
 
   it(`given that ADYEN sends a "CANCELLATION is successful" notification
@@ -380,6 +396,10 @@ describe('notification module', () => {
           type: 'CancelAuthorization',
           interactionId: 'test_AUTHORISATION_1',
         },
+      },
+      {
+        action: 'setKey',
+        key: 'test_AUTHORISATION_1',
       },
     ]
 
@@ -477,6 +497,10 @@ describe('notification module', () => {
           interactionId: 'test_AUTHORISATION_1',
         },
       },
+      {
+        action: 'setKey',
+        key: 'test_AUTHORISATION_1',
+      },
     ]
 
     // assert update actions
@@ -573,6 +597,10 @@ describe('notification module', () => {
           interactionId: 'test_AUTHORISATION_1',
           timestamp: '',
         },
+      },
+      {
+        action: 'setKey',
+        key: 'test_AUTHORISATION_1',
       },
     ]
 
@@ -676,6 +704,10 @@ describe('notification module', () => {
         action: 'changeTransactionTimestamp',
         transactionId: '9ca92d05-ba63-47dc-8f83-95b08d539646',
         timestamp: '2022-04-13T05:17:29.000Z',
+      },
+      {
+        action: 'setKey',
+        key: '****',
       },
     ]
 

--- a/notification/test/unit/notification.handler.spec.js
+++ b/notification/test/unit/notification.handler.spec.js
@@ -91,8 +91,8 @@ describe('notification module', () => {
       state: 'Initial',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
-      body: { results: [payment] },
+    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
+      body: payment,
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -194,8 +194,8 @@ describe('notification module', () => {
       state: 'Pending',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
-      body: { results: [payment] },
+    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
+      body: payment,
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -286,8 +286,8 @@ describe('notification module', () => {
       },
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
-      body: { results: [payment] },
+    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
+      body: payment,
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -341,8 +341,8 @@ describe('notification module', () => {
       state: 'Pending',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
-      body: { results: [payment] },
+    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
+      body: payment,
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -437,8 +437,8 @@ describe('notification module', () => {
       state: 'Success',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
-      body: { results: [payment] },
+    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
+      body: payment,
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -533,8 +533,8 @@ describe('notification module', () => {
       state: 'Success',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
-      body: { results: [payment] },
+    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
+      body: payment,
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -639,8 +639,8 @@ describe('notification module', () => {
       interactionId: 'test_AUTHORISATION_1',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
-      body: { results: [payment] },
+    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
+      body: payment,
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -702,8 +702,8 @@ describe('notification module', () => {
       state: 'Initial',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
-      body: { results: [modifiedPaymentMock] },
+    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
+      body: modifiedPaymentMock,
     }))
     sandbox.stub(ctpClient, 'fetchById').callsFake(() => ({
       body: modifiedPaymentMock,
@@ -733,24 +733,6 @@ describe('notification module', () => {
     expect(ctpClientUpdateSpy.callCount).to.equal(21)
   })
 
-  it('do not make any requests when merchantReference cannot be extracted from notification', async () => {
-    const ctpClient = ctpClientMock.get(ctpConfig)
-    const ctpClientFetchByKeySpy = sandbox.spy(ctpClient, 'fetchByKeys')
-    const ctpClientFetchByIdSpy = sandbox.spy(ctpClient, 'fetchById')
-    const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
-    ctp.get = () => ctpClient
-
-    // process
-    await notificationHandler.processNotification(
-      { name: 'some wrong notification' },
-      false,
-      config
-    )
-
-    expect(ctpClientFetchByKeySpy.callCount).to.equal(0)
-    expect(ctpClientFetchByIdSpy.callCount).to.equal(0)
-    expect(ctpClientUpdateSpy.callCount).to.equal(0)
-  })
   it(
     'when "removeSensitiveData" is false, ' +
       'then it should not remove sensitive data',
@@ -797,8 +779,8 @@ describe('notification module', () => {
       ]
       const payment = cloneDeep(paymentMock)
       const ctpClient = ctpClientMock.get(ctpConfig)
-      sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
-        body: { results: [payment] },
+      sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
+        body: payment,
       }))
       const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
       ctp.get = () => ctpClient
@@ -865,8 +847,8 @@ describe('notification module', () => {
       ]
       const payment = cloneDeep(paymentMock)
       const ctpClient = ctpClientMock.get(ctpConfig)
-      sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
-        body: { results: [payment] },
+      sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
+        body: payment,
       }))
       const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
       ctp.get = () => ctpClient
@@ -925,7 +907,7 @@ describe('notification module', () => {
       state: 'Success',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => {
+    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => {
       throw new Error('error')
     })
 
@@ -942,8 +924,6 @@ describe('notification module', () => {
       error = e
     }
     expect(error instanceof VError).to.equal(true)
-    expect(error.message).to.contains(
-      'Failed to fetch a payment with merchantReference'
-    )
+    expect(error.message).to.contains('Failed to fetch a payment with key')
   })
 })

--- a/notification/test/unit/notification.handler.spec.js
+++ b/notification/test/unit/notification.handler.spec.js
@@ -91,8 +91,8 @@ describe('notification module', () => {
       state: 'Initial',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: payment,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [payment] },
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -128,6 +128,10 @@ describe('notification module', () => {
         action: 'changeTransactionTimestamp',
         transactionId: '9ca92d05-ba63-47dc-8f83-95b08d539646',
         timestamp: '2021-01-01T10:00:00.000Z',
+      },
+      {
+        action: 'setKey',
+        key: 'test_AUTHORISATION_1',
       },
       {
         action: 'setMethodInfoMethod',
@@ -190,8 +194,8 @@ describe('notification module', () => {
       state: 'Pending',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: payment,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [payment] },
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -282,8 +286,8 @@ describe('notification module', () => {
       },
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: payment,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [payment] },
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -337,8 +341,8 @@ describe('notification module', () => {
       state: 'Pending',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: payment,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [payment] },
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -433,8 +437,8 @@ describe('notification module', () => {
       state: 'Success',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: payment,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [payment] },
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -529,8 +533,8 @@ describe('notification module', () => {
       state: 'Success',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: payment,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [payment] },
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -635,8 +639,8 @@ describe('notification module', () => {
       interactionId: 'test_AUTHORISATION_1',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: payment,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [payment] },
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -698,8 +702,8 @@ describe('notification module', () => {
       state: 'Initial',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: modifiedPaymentMock,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [modifiedPaymentMock] },
     }))
     sandbox.stub(ctpClient, 'fetchById').callsFake(() => ({
       body: modifiedPaymentMock,
@@ -731,7 +735,7 @@ describe('notification module', () => {
 
   it('do not make any requests when merchantReference cannot be extracted from notification', async () => {
     const ctpClient = ctpClientMock.get(ctpConfig)
-    const ctpClientFetchByKeySpy = sandbox.spy(ctpClient, 'fetchByKey')
+    const ctpClientFetchByKeySpy = sandbox.spy(ctpClient, 'fetchByKeys')
     const ctpClientFetchByIdSpy = sandbox.spy(ctpClient, 'fetchById')
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -793,8 +797,8 @@ describe('notification module', () => {
       ]
       const payment = cloneDeep(paymentMock)
       const ctpClient = ctpClientMock.get(ctpConfig)
-      sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-        body: payment,
+      sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+        body: { results: [payment] },
       }))
       const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
       ctp.get = () => ctpClient
@@ -861,8 +865,8 @@ describe('notification module', () => {
       ]
       const payment = cloneDeep(paymentMock)
       const ctpClient = ctpClientMock.get(ctpConfig)
-      sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-        body: payment,
+      sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+        body: { results: [payment] },
       }))
       const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
       ctp.get = () => ctpClient
@@ -921,7 +925,7 @@ describe('notification module', () => {
       state: 'Success',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => {
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => {
       throw new Error('error')
     })
 

--- a/notification/test/unit/notification.handler.spec.js
+++ b/notification/test/unit/notification.handler.spec.js
@@ -91,8 +91,8 @@ describe('notification module', () => {
       state: 'Initial',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: payment,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [payment] },
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -194,8 +194,8 @@ describe('notification module', () => {
       state: 'Pending',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: payment,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [payment] },
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -296,8 +296,8 @@ describe('notification module', () => {
       },
     ]
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: payment,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [payment] },
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -357,8 +357,8 @@ describe('notification module', () => {
       state: 'Pending',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: payment,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [payment] },
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -457,8 +457,8 @@ describe('notification module', () => {
       state: 'Success',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: payment,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [payment] },
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -557,8 +557,8 @@ describe('notification module', () => {
       state: 'Success',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: payment,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [payment] },
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -667,8 +667,8 @@ describe('notification module', () => {
       interactionId: 'test_AUTHORISATION_1',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: payment,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [payment] },
     }))
     const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
     ctp.get = () => ctpClient
@@ -734,8 +734,8 @@ describe('notification module', () => {
       state: 'Initial',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-      body: modifiedPaymentMock,
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+      body: { results: [modifiedPaymentMock] },
     }))
     sandbox.stub(ctpClient, 'fetchById').callsFake(() => ({
       body: modifiedPaymentMock,
@@ -765,6 +765,24 @@ describe('notification module', () => {
     expect(ctpClientUpdateSpy.callCount).to.equal(21)
   })
 
+  it('do not make any requests when merchantReference cannot be extracted from notification', async () => {
+    const ctpClient = ctpClientMock.get(ctpConfig)
+    const ctpClientFetchByKeySpy = sandbox.spy(ctpClient, 'fetchByKeys')
+    const ctpClientFetchByIdSpy = sandbox.spy(ctpClient, 'fetchById')
+    const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
+    ctp.get = () => ctpClient
+
+    // process
+    await notificationHandler.processNotification(
+      { name: 'some wrong notification' },
+      false,
+      config
+    )
+
+    expect(ctpClientFetchByKeySpy.callCount).to.equal(0)
+    expect(ctpClientFetchByIdSpy.callCount).to.equal(0)
+    expect(ctpClientUpdateSpy.callCount).to.equal(0)
+  })
   it(
     'when "removeSensitiveData" is false, ' +
       'then it should not remove sensitive data',
@@ -811,8 +829,8 @@ describe('notification module', () => {
       ]
       const payment = cloneDeep(paymentMock)
       const ctpClient = ctpClientMock.get(ctpConfig)
-      sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-        body: payment,
+      sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+        body: { results: [payment] },
       }))
       const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
       ctp.get = () => ctpClient
@@ -879,8 +897,8 @@ describe('notification module', () => {
       ]
       const payment = cloneDeep(paymentMock)
       const ctpClient = ctpClientMock.get(ctpConfig)
-      sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => ({
-        body: payment,
+      sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => ({
+        body: { results: [payment] },
       }))
       const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
       ctp.get = () => ctpClient
@@ -939,7 +957,7 @@ describe('notification module', () => {
       state: 'Success',
     })
     const ctpClient = ctpClientMock.get(ctpConfig)
-    sandbox.stub(ctpClient, 'fetchByKey').callsFake(() => {
+    sandbox.stub(ctpClient, 'fetchByKeys').callsFake(() => {
       throw new Error('error')
     })
 
@@ -956,6 +974,8 @@ describe('notification module', () => {
       error = e
     }
     expect(error instanceof VError).to.equal(true)
-    expect(error.message).to.contains('Failed to fetch a payment with key')
+    expect(error.message).to.contains(
+      'Failed to fetch a payment with merchantReference'
+    )
   })
 })

--- a/notification/test/unit/notification.handler.spec.js
+++ b/notification/test/unit/notification.handler.spec.js
@@ -765,24 +765,6 @@ describe('notification module', () => {
     expect(ctpClientUpdateSpy.callCount).to.equal(21)
   })
 
-  it('do not make any requests when merchantReference cannot be extracted from notification', async () => {
-    const ctpClient = ctpClientMock.get(ctpConfig)
-    const ctpClientFetchByKeySpy = sandbox.spy(ctpClient, 'fetchByKeys')
-    const ctpClientFetchByIdSpy = sandbox.spy(ctpClient, 'fetchById')
-    const ctpClientUpdateSpy = sandbox.spy(ctpClient, 'update')
-    ctp.get = () => ctpClient
-
-    // process
-    await notificationHandler.processNotification(
-      { name: 'some wrong notification' },
-      false,
-      config
-    )
-
-    expect(ctpClientFetchByKeySpy.callCount).to.equal(0)
-    expect(ctpClientFetchByIdSpy.callCount).to.equal(0)
-    expect(ctpClientUpdateSpy.callCount).to.equal(0)
-  })
   it(
     'when "removeSensitiveData" is false, ' +
       'then it should not remove sensitive data',


### PR DESCRIPTION
**Extension**
- Set the `pspReference` to payment key if it exists in the response in making payment and submitting additional payment details. If it is not found within response, put `merchantReference` as payment key.

**Notification**
- Get payment by original reference or psp reference or merchant reference. Not only by merchant reference
- Update the payment key by pspReference if notification represents a successful authorization and the old transaction is not yet successful.