### PR TITLE
Handle non-JSON response

### DIFF
--- a/extension/src/config/constants.js
+++ b/extension/src/config/constants.js
@@ -41,4 +41,10 @@ export default {
   CTP_INTERACTION_TYPE_AMOUNT_UPDATES: 'amountUpdates',
   CTP_INTERACTION_TYPE_DISABLE_STORED_PAYMENT: 'disableStoredPayment',
   CTP_DISABLE_STORED_PAYMENT_RESPONSE: 'disableStoredPaymentResponse',
+  ADYEN_LEGACY_API_VERSION: {
+    MANUAL_CAPTURE: 'v64',
+    CANCEL: 'v64',
+    REFUND: 'v64',
+    DISABLED_STORED_PAYMENT: 'v68',
+  },
 }

--- a/extension/src/service/web-component-service.js
+++ b/extension/src/service/web-component-service.js
@@ -225,7 +225,9 @@ async function fetchAsync(
   } catch (err) {
     if (response)
       // Handle non-JSON format response
-      responseBody = responseBodyInText
+      throw new Error(
+        `Unable to receive non-JSON format resposne from Adyen API : ${responseBodyInText}`
+      )
     // Error in fetching URL
     else throw err
   } finally {

--- a/extension/src/service/web-component-service.js
+++ b/extension/src/service/web-component-service.js
@@ -135,7 +135,6 @@ function disableStoredPayment(merchantAccount, disableStoredPaymentRequestObj) {
   const url =
     `${adyenCredentials.legacyApiBaseUrl}/Recurring/` +
     `${constants.ADYEN_LEGACY_API_VERSION.DISABLED_STORED_PAYMENT}/disable`
-  console.log(url)
   return callAdyen(
     url,
     merchantAccount,

--- a/extension/src/service/web-component-service.js
+++ b/extension/src/service/web-component-service.js
@@ -132,9 +132,12 @@ function updateAmount(
 
 function disableStoredPayment(merchantAccount, disableStoredPaymentRequestObj) {
   const adyenCredentials = config.getAdyenConfig(merchantAccount)
+  const url =
+    `${adyenCredentials.legacyApiBaseUrl}/Recurring/` +
+    `${constants.ADYEN_LEGACY_API_VERSION.DISABLED_STORED_PAYMENT}/disable`
+  console.log(url)
   return callAdyen(
-    `${adyenCredentials.legacyApiBaseUrl}/Recurring/
-    ${constants.ADYEN_LEGACY_API_VERSION.DISABLED_STORED_PAYMENT}/disable`,
+    url,
     merchantAccount,
     adyenCredentials.apiKey,
     disableStoredPaymentRequestObj

--- a/extension/src/service/web-component-service.js
+++ b/extension/src/service/web-component-service.js
@@ -133,7 +133,8 @@ function updateAmount(
 function disableStoredPayment(merchantAccount, disableStoredPaymentRequestObj) {
   const adyenCredentials = config.getAdyenConfig(merchantAccount)
   return callAdyen(
-    `${adyenCredentials.legacyApiBaseUrl}/Recurring/${constants.ADYEN_LEGACY_API_VERSION.DISABLED_STORED_PAYMENT}/disable`,
+    `${adyenCredentials.legacyApiBaseUrl}/Recurring/
+    ${constants.ADYEN_LEGACY_API_VERSION.DISABLED_STORED_PAYMENT}/disable`,
     merchantAccount,
     adyenCredentials.apiKey,
     disableStoredPaymentRequestObj

--- a/extension/src/service/web-component-service.js
+++ b/extension/src/service/web-component-service.js
@@ -2,6 +2,7 @@ import fetch from 'node-fetch'
 import { serializeError } from 'serialize-error'
 import config from '../config/config.js'
 import utils from '../utils.js'
+import constants from '../config/constants.js'
 
 async function getPaymentMethods(merchantAccount, getPaymentMethodsRequestObj) {
   const adyenCredentials = config.getAdyenConfig(merchantAccount)
@@ -63,7 +64,7 @@ function manualCapture(
   const adyenCredentials = config.getAdyenConfig(merchantAccount)
   extendRequestObjWithMetadata(manualCaptureRequestObj, commercetoolsProjectKey)
   return callAdyen(
-    `${adyenCredentials.legacyApiBaseUrl}/Payment/v64/capture`,
+    `${adyenCredentials.legacyApiBaseUrl}/Payment/${constants.ADYEN_LEGACY_API_VERSION.MANUAL_CAPTURE}/capture`,
     merchantAccount,
     adyenCredentials.apiKey,
     manualCaptureRequestObj,
@@ -79,7 +80,7 @@ function cancelPayment(
   const adyenCredentials = config.getAdyenConfig(merchantAccount)
   extendRequestObjWithMetadata(cancelPaymentRequestObj)
   return callAdyen(
-    `${adyenCredentials.legacyApiBaseUrl}/Payment/v64/cancel`,
+    `${adyenCredentials.legacyApiBaseUrl}/Payment/${constants.ADYEN_LEGACY_API_VERSION.CANCEL}/cancel`,
     merchantAccount,
     adyenCredentials.apiKey,
     cancelPaymentRequestObj
@@ -95,7 +96,7 @@ function refund(
   const adyenCredentials = config.getAdyenConfig(merchantAccount)
   extendRequestObjWithMetadata(refundRequestObj, commercetoolsProjectKey)
   return callAdyen(
-    `${adyenCredentials.legacyApiBaseUrl}/Payment/v64/refund`,
+    `${adyenCredentials.legacyApiBaseUrl}/Payment/${constants.ADYEN_LEGACY_API_VERSION.REFUND}/refund`,
     merchantAccount,
     adyenCredentials.apiKey,
     refundRequestObj,
@@ -132,7 +133,7 @@ function updateAmount(
 function disableStoredPayment(merchantAccount, disableStoredPaymentRequestObj) {
   const adyenCredentials = config.getAdyenConfig(merchantAccount)
   return callAdyen(
-    `${adyenCredentials.legacyApiBaseUrl}/Recurring/v68/disable`,
+    `${adyenCredentials.legacyApiBaseUrl}/Recurring/${constants.ADYEN_LEGACY_API_VERSION.DISABLED_STORED_PAYMENT}/disable`,
     merchantAccount,
     adyenCredentials.apiKey,
     disableStoredPaymentRequestObj

--- a/extension/test/unit/refund-payment.handler.spec.js
+++ b/extension/test/unit/refund-payment.handler.spec.js
@@ -112,13 +112,14 @@ describe('refund-payment::execute', () => {
       const adyenResponse = response.actions.find(
         (action) => action.action === 'addInterfaceInteraction'
       ).fields.response
+
       const adyenRequestJson = JSON.parse(adyenRequest)
       const requestBody = JSON.parse(adyenRequestJson.body)
 
       expect(requestBody.reference).to.equal(
         refundPaymentTransaction.custom.fields.reference
       )
-      expect(adyenResponse).to.equal('"non-json-response"')
+      expect(adyenResponse).to.contains('non-json-response')
     }
   )
 })

--- a/extension/test/unit/refund-payment.handler.spec.js
+++ b/extension/test/unit/refund-payment.handler.spec.js
@@ -4,8 +4,9 @@ import { expect } from 'chai'
 import config from '../../src/config/config.js'
 import refundPaymentHandler from '../../src/paymentHandler/refund-payment.handler.js'
 import utils from '../../src/utils.js'
-import { overrideGenerateIdempotencyKeyConfig } from '../test-utils.js'
 import constants from '../../src/config/constants.js'
+import { overrideGenerateIdempotencyKeyConfig } from '../test-utils.js'
+
 const { execute } = refundPaymentHandler
 
 describe('refund-payment::execute', () => {

--- a/extension/test/unit/refund-payment.handler.spec.js
+++ b/extension/test/unit/refund-payment.handler.spec.js
@@ -93,28 +93,32 @@ describe('refund-payment::execute', () => {
     }
   )
 
-  it('when refund payment response contains non-JSON format, then it should return the response in plain text inside interfaceInteraction', async () => {
-    scope.post('/refund').reply(200, 'non-json-response')
+  it(
+    'when refund payment response contains non-JSON format, ' +
+      'then it should return the response in plain text inside interfaceInteraction',
+    async () => {
+      scope.post('/refund').reply(200, 'non-json-response')
 
-    const ctpPaymentClone = _.cloneDeep(ctpPayment)
+      const ctpPaymentClone = _.cloneDeep(ctpPayment)
 
-    ctpPaymentClone.transactions.push(refundPaymentTransaction)
-    ctpPaymentClone.custom.fields.adyenMerchantAccount = adyenMerchantAccount
+      ctpPaymentClone.transactions.push(refundPaymentTransaction)
+      ctpPaymentClone.custom.fields.adyenMerchantAccount = adyenMerchantAccount
 
-    const response = await execute(ctpPaymentClone)
+      const response = await execute(ctpPaymentClone)
 
-    const adyenRequest = response.actions.find(
-      (action) => action.action === 'addInterfaceInteraction'
-    ).fields.request
-    const adyenResponse = response.actions.find(
-      (action) => action.action === 'addInterfaceInteraction'
-    ).fields.response
-    const adyenRequestJson = JSON.parse(adyenRequest)
-    const requestBody = JSON.parse(adyenRequestJson.body)
+      const adyenRequest = response.actions.find(
+        (action) => action.action === 'addInterfaceInteraction'
+      ).fields.request
+      const adyenResponse = response.actions.find(
+        (action) => action.action === 'addInterfaceInteraction'
+      ).fields.response
+      const adyenRequestJson = JSON.parse(adyenRequest)
+      const requestBody = JSON.parse(adyenRequestJson.body)
 
-    expect(requestBody.reference).to.equal(
-      refundPaymentTransaction.custom.fields.reference
-    )
-    expect(adyenResponse).to.equal('"non-json-response"')
-  })
+      expect(requestBody.reference).to.equal(
+        refundPaymentTransaction.custom.fields.reference
+      )
+      expect(adyenResponse).to.equal('"non-json-response"')
+    }
+  )
 })

--- a/extension/test/unit/refund-payment.handler.spec.js
+++ b/extension/test/unit/refund-payment.handler.spec.js
@@ -5,7 +5,7 @@ import config from '../../src/config/config.js'
 import refundPaymentHandler from '../../src/paymentHandler/refund-payment.handler.js'
 import utils from '../../src/utils.js'
 import { overrideGenerateIdempotencyKeyConfig } from '../test-utils.js'
-
+import constants from '../../src/config/constants.js'
 const { execute } = refundPaymentHandler
 
 describe('refund-payment::execute', () => {
@@ -43,7 +43,9 @@ describe('refund-payment::execute', () => {
 
   beforeEach(() => {
     const adyenConfig = config.getAdyenConfig(adyenMerchantAccount)
-    scope = nock(`${adyenConfig.legacyApiBaseUrl}/Payment/v64`)
+    scope = nock(
+      `${adyenConfig.legacyApiBaseUrl}/Payment/${constants.ADYEN_LEGACY_API_VERSION.REFUND}`
+    )
   })
 
   afterEach(() => {


### PR DESCRIPTION
Fixes : #1052 

- When we receive the response from Adyen API call, now we check if the response is JSON format. If it isn't, we would put it as plain text response into `InterfaceInteractions` so that user would know what actually happen.

- Fix other refund unit test cases since mocking response for payment API call is not applicable.