### PR TITLE
Fix shopperIP

### DIFF
--- a/extension/src/api/payment/payment.controller.js
+++ b/extension/src/api/payment/payment.controller.js
@@ -28,7 +28,6 @@ async function processRequest(request, response, logger) {
   try {
     const authToken = getAuthorizationRequestHeader(request)
     paymentObject = await _getPaymentObject(request, logger)
-    paymentObject.shopperIP = getIPAddressRequestHeader(request)
     const paymentLogger = logger.child({ paymentId: paymentObject.id })
     paymentLogger.debug(
       'Received payment object',
@@ -80,10 +79,6 @@ async function _getPaymentObject(request, logger) {
     logger.error(errorStackTrace)
     throw err
   }
-}
-
-function getIPAddressRequestHeader(request) {
-  return request?.headers?.['x-forwarded-for']
 }
 
 export default { processRequest }

--- a/extension/src/paymentHandler/make-payment.handler.js
+++ b/extension/src/paymentHandler/make-payment.handler.js
@@ -26,7 +26,6 @@ async function execute(paymentObject) {
     commercetoolsProjectKey,
   )
 
-  makePaymentRequestObj.shopperIP = paymentObject.shopperIP
   paymentObject.custom.fields.makePaymentRequest = JSON.stringify(
     makePaymentRequestObj,
   )

--- a/extension/src/paymentHandler/sessions-request.handler.js
+++ b/extension/src/paymentHandler/sessions-request.handler.js
@@ -22,7 +22,6 @@ async function execute(paymentObject) {
     commercetoolsProjectKey,
   )
 
-  createSessionRequestObj.shopperIP = paymentObject.shopperIP
   paymentObject.custom.fields.createSessionRequest = JSON.stringify(
     createSessionRequestObj,
   )

--- a/extension/test/unit/create-session-request.handler.spec.js
+++ b/extension/test/unit/create-session-request.handler.spec.js
@@ -65,6 +65,7 @@ describe('create-session-request::execute::', () => {
       firstName: 'Test',
       lastName: 'Customer',
     },
+    shopperIP: '127.0.0.1',
   }
 
   const paymentObjectWithAdditionalFields = {
@@ -253,6 +254,9 @@ describe('create-session-request::execute::', () => {
       expect(createSessionRequestJson.shopperName.lastName).to.equal(
         getSessionRequestWithAdditionalFields.shopperName.lastName,
       )
+      expect(createSessionRequestJson.shopperIP).to.equal(
+        getSessionRequestWithAdditionalFields.shopperIP,
+      )
 
       expect(createSessionRequestJson.billingAddress.street).to.equal(
         ctpCartWithCustomer.billingAddress.streetName,
@@ -360,6 +364,7 @@ describe('create-session-request::execute::', () => {
       expect(createSessionRequestJson.shopperName.lastName).to.equal(
         ctpCustomer.lastName,
       )
+      expect(createSessionRequestJson.shopperIP).to.be.undefined
     },
   )
 
@@ -397,6 +402,7 @@ describe('create-session-request::execute::', () => {
       expect(createSessionRequestJson).to.not.have.own.property('shopperEmail')
       expect(createSessionRequestJson).to.not.have.own.property('accountInfo')
       expect(createSessionRequestJson).to.not.have.own.property('shopperName')
+      expect(createSessionRequestJson).to.not.have.own.property('shopperIP')
       expect(createSessionRequestJson).to.not.have.own.property('shopperLocale')
     },
   )

--- a/extension/test/unit/make-payment.handler.spec.js
+++ b/extension/test/unit/make-payment.handler.spec.js
@@ -110,6 +110,7 @@ describe('make-payment::execute', () => {
       firstName: 'Test',
       lastName: 'Customer',
     },
+    shopperIP: '127.0.0.1',
   }
   const adyenMerchantAccount = config.getAllAdyenMerchantAccounts()[0]
   const commercetoolsProjectKey = config.getAllCtpProjectKeys()[0]
@@ -600,6 +601,9 @@ describe('make-payment::execute', () => {
       expect(makePaymentRequestJson.shopperName.lastName).to.equal(
         makePaymentRequestClone.shopperName.lastName,
       )
+      expect(makePaymentRequestJson.shopperIP).to.equal(
+        makePaymentRequestClone.shopperIP,
+      )
 
       expect(makePaymentRequestJson.billingAddress.street).to.equal(
         ctpCartWithCustomer.billingAddress.streetName,
@@ -720,6 +724,7 @@ describe('make-payment::execute', () => {
       expect(makePaymentRequestJson.shopperName.lastName).to.equal(
         ctpCustomer.lastName,
       )
+      expect(makePaymentRequestJson.shopperIP).to.be.undefined
     },
   )
 
@@ -760,6 +765,7 @@ describe('make-payment::execute', () => {
       expect(makePaymentRequestJson).to.not.have.own.property('shopperEmail')
       expect(makePaymentRequestJson).to.not.have.own.property('accountInfo')
       expect(makePaymentRequestJson).to.not.have.own.property('shopperName')
+      expect(makePaymentRequestJson).to.not.have.own.property('shopperIP')
       expect(makePaymentRequestJson).to.not.have.own.property('shopperLocale')
       expect(makePaymentRequestJson.additionalData).to.not.have.own.property(
         'enhancedSchemeData.destinationCountryCode',


### PR DESCRIPTION
## Summary
Fix `shopperIP` field in `makePaymentRequest` and `createSessionRequest` objects:
Currently, `payment.controller.js` unconditionally sets the `shopperIP` field on `paymentObject` to the value from the requests `x-forwarded-for` header and then applies it to the initial request object later on.
This means that any `shopperIP` provided by the initial request gets lost.
Additionally, the `x-forwarded-for` header contains a wrong value (most likely the Commercetools server IP), so it should not be used as a fallback at all.
Instead, if `shopperIP` is missing in the clients request, it should just stay `undefined`.

## Tested scenarios
- `makePaymentRequest` contains `shopperIP` -> `shopperIP` will be forwarded to Adyen
- `makePaymentRequest` doesn't contain `shopperIP` ->`shopperIP` stays `undefined`
- `createSessionRequest` contains `shopperIP` -> `shopperIP` will be forwarded to Adyen
- `createSessionRequest` doesn't contain `shopperIP` -> `shopperIP` stays `undefined`

**Fixed issue**:  <!-- #-prefixed issue number -->
